### PR TITLE
feat(planning): add enable_pruning flag to all map configs

### DIFF
--- a/map/city.yml
+++ b/map/city.yml
@@ -26,6 +26,11 @@ planner:
   # code expects normalized units (physical / step_size) but the value was
   # set as if it were meters, creating ~16 coarse cells that starved the tree.
   witness_radius: 0.5  # [] SST witness-cell half-width in normalized units
+  # Path pruning is a performance optimisation with a safety trade-off: it
+  # produces a smoother but riskier path by shortcutting intermediate
+  # waypoints.  To remain collision-free after pruning, all safety margins
+  # must be increased.  Disabled by default.
+  enable_pruning: false  # [] enable trajectory pruning (smooths path but requires larger safety margins)
 
 world:
   world_width: 1280.0  # [m] width of the world

--- a/map/occ.yml
+++ b/map/occ.yml
@@ -46,6 +46,11 @@ planner:
   sst_max_sample_count: 40000  # [] maximum number of SST samples
   witness_radius: 0.5            # [] normalized distance for SST witness cells
   cspace_grid_n: 120  # [] grid resolution for C-space sampling (n^3 points evaluated)
+  # Path pruning is a performance optimisation with a safety trade-off: it
+  # produces a smoother but riskier path by shortcutting intermediate
+  # waypoints.  To remain collision-free after pruning, all safety margins
+  # must be increased.  Disabled by default.
+  enable_pruning: false  # [] enable trajectory pruning (smooths path but requires larger safety margins)
 
 control:
   # Position PD — target: ωn ≈ 0.71 rad/s, ζ ≈ 0.59 → ~10 % overshoot.

--- a/map/ppp.yml
+++ b/map/ppp.yml
@@ -44,6 +44,11 @@ planner:
   rrt_max_sample_count: 10000  # [] maximum number of RRT* samples
   sst_max_sample_count: 8000  # [] maximum number of SST samples
   witness_radius: 0.7  # [m] SST witness cell radius
+  # Path pruning is a performance optimisation with a safety trade-off: it
+  # produces a smoother but riskier path by shortcutting intermediate
+  # waypoints.  To remain collision-free after pruning, all safety margins
+  # must be increased.  Disabled by default.
+  enable_pruning: false  # [] enable trajectory pruning (smooths path but requires larger safety margins)
 
 # ---------------------------------------------------------------------------
 # Simulation / visualisation parameters

--- a/map/rr.yml
+++ b/map/rr.yml
@@ -46,6 +46,11 @@ planner:
   rrt_max_sample_count: 30000  # [] maximum number of RRT* samples
   sst_max_sample_count: 40000  # [] maximum number of SST samples
   witness_radius: 0.05  # [rad] SST witness cell radius (less than half the step size)
+  # Path pruning is a performance optimisation with a safety trade-off: it
+  # produces a smoother but riskier path by shortcutting intermediate
+  # waypoints.  To remain collision-free after pruning, all safety margins
+  # must be increased.  Disabled by default.
+  enable_pruning: false  # [] enable trajectory pruning (smooths path but requires larger safety margins)
 
 # ---------------------------------------------------------------------------
 # Simulator parameters

--- a/map/rrp.yml
+++ b/map/rrp.yml
@@ -71,6 +71,11 @@ planner:
 
   # Grid resolution for C-space sampling (n^3 points evaluated).
   cspace_grid_n: 80  # [] grid resolution for C-space sampling (n^3 points evaluated)
+  # Path pruning is a performance optimisation with a safety trade-off: it
+  # produces a smoother but riskier path by shortcutting intermediate
+  # waypoints.  To remain collision-free after pruning, all safety margins
+  # must be increased.  Disabled by default.
+  enable_pruning: false  # [] enable trajectory pruning (smooths path but requires larger safety margins)
 
 # ---------------------------------------------------------------------------
 # Simulator parameters

--- a/map/vehicle.yml
+++ b/map/vehicle.yml
@@ -13,6 +13,11 @@ planner:
   sst_max_sample_count: 4000  # [] maximum number of SST samples
   witness_radius: 0.8  # [m] SST witness cell radius
   early_stop: true  # [] stop planning when first valid path is found
+  # Path pruning is a performance optimisation with a safety trade-off: it
+  # produces a smoother but riskier path by shortcutting intermediate
+  # waypoints.  To remain collision-free after pruning, all safety margins
+  # must be increased.  Disabled by default.
+  enable_pruning: false  # [] enable trajectory pruning (smooths path but requires larger safety margins)
 
 world:
   random_seed: 7  # [] random seed for world generation

--- a/src/arco/tools/examples/ppp.py
+++ b/src/arco/tools/examples/ppp.py
@@ -196,10 +196,15 @@ def main(cfg: dict, save_path: str | None = None) -> None:
         logger.warning("SST: no path found.")
 
     # --- Path pruning + trajectory optimisation (3-D) ----------------------
-    pruner = TrajectoryPruner(
-        occ,
-        step_size=np.asarray(planner_cfg["step_size"], dtype=float),
-        collision_check_count=int(planner_cfg["collision_check_count"]),
+    _enable_pruning = bool(planner_cfg.get("enable_pruning", False))
+    pruner = (
+        TrajectoryPruner(
+            occ,
+            step_size=np.asarray(planner_cfg["step_size"], dtype=float),
+            collision_check_count=int(planner_cfg["collision_check_count"]),
+        )
+        if _enable_pruning
+        else None
     )
     opt = TrajectoryOptimizer(
         occ,
@@ -220,7 +225,9 @@ def main(cfg: dict, save_path: str | None = None) -> None:
     rrt_opt_status = "not-run"
     sst_opt_status = "not-run"
     if rrt_path is not None:
-        rrt_path = pruner.prune(rrt_path)
+        rrt_path = (
+            pruner.prune(rrt_path) if pruner is not None else list(rrt_path)
+        )
         try:
             res = opt.optimize(rrt_path)
             rrt_traj = res.states
@@ -236,7 +243,9 @@ def main(cfg: dict, save_path: str | None = None) -> None:
             )
             rrt_opt_status = "exception"
     if sst_path is not None:
-        sst_path = pruner.prune(sst_path)
+        sst_path = (
+            pruner.prune(sst_path) if pruner is not None else list(sst_path)
+        )
         try:
             res = opt.optimize(sst_path)
             sst_traj = res.states

--- a/src/arco/tools/examples/rr.py
+++ b/src/arco/tools/examples/rr.py
@@ -215,10 +215,15 @@ def main(cfg: dict, save_path: str | None = None) -> None:
     sst_len = polyline_length(sst_path)
 
     # --- Trajectory optimisation --------------------------------------------
-    pruner = TrajectoryPruner(
-        occ,
-        step_size=np.asarray(planner_cfg["step_size"], dtype=float),
-        collision_check_count=int(planner_cfg["collision_check_count"]),
+    _enable_pruning = bool(planner_cfg.get("enable_pruning", False))
+    pruner = (
+        TrajectoryPruner(
+            occ,
+            step_size=np.asarray(planner_cfg["step_size"], dtype=float),
+            collision_check_count=int(planner_cfg["collision_check_count"]),
+        )
+        if _enable_pruning
+        else None
     )
     optimizer = TrajectoryOptimizer(
         occ,
@@ -236,7 +241,7 @@ def main(cfg: dict, save_path: str | None = None) -> None:
     ) -> tuple[list[np.ndarray] | None, float, str]:
         if path is None or len(path) < 2:
             return None, 0.0, "no-path"
-        path = pruner.prune(path)
+        path = pruner.prune(path) if pruner is not None else list(path)
         try:
             result = optimizer.optimize(path)
             traj = list(result.states)

--- a/src/arco/tools/examples/rrp.py
+++ b/src/arco/tools/examples/rrp.py
@@ -354,10 +354,15 @@ def main(cfg: dict, save_path: str | None = None) -> None:
     sst_len = polyline_length(sst_path)
 
     # --- Trajectory optimisation -------------------------------------------
-    pruner = TrajectoryPruner(
-        occ,
-        step_size=np.asarray(planner_cfg["step_size"], dtype=float),
-        collision_check_count=int(planner_cfg["collision_check_count"]),
+    _enable_pruning = bool(planner_cfg.get("enable_pruning", False))
+    pruner = (
+        TrajectoryPruner(
+            occ,
+            step_size=np.asarray(planner_cfg["step_size"], dtype=float),
+            collision_check_count=int(planner_cfg["collision_check_count"]),
+        )
+        if _enable_pruning
+        else None
     )
     opt = TrajectoryOptimizer(
         occ,
@@ -389,7 +394,9 @@ def main(cfg: dict, save_path: str | None = None) -> None:
         pass  # parsed below, kept for structure
 
     if rrt_path is not None:
-        rrt_path = pruner.prune(rrt_path)
+        rrt_path = (
+            pruner.prune(rrt_path) if pruner is not None else list(rrt_path)
+        )
         try:
             res = opt.optimize(rrt_path)
             rrt_traj = res.states
@@ -401,7 +408,9 @@ def main(cfg: dict, save_path: str | None = None) -> None:
             logger.exception("RRT* TrajectoryOptimizer failed; skipping.")
             rrt_opt_status = "exception"
     if sst_path is not None:
-        sst_path = pruner.prune(sst_path)
+        sst_path = (
+            pruner.prune(sst_path) if pruner is not None else list(sst_path)
+        )
         try:
             res = opt.optimize(sst_path)
             sst_traj = res.states

--- a/src/arco/tools/examples/vehicle.py
+++ b/src/arco/tools/examples/vehicle.py
@@ -93,6 +93,7 @@ def _optimize(
     path: list[np.ndarray] | None,
     vehicle_cfg: dict,
     step_size: np.ndarray,
+    enable_pruning: bool = False,
 ) -> tuple[list[np.ndarray] | None, float, str]:
     """Prune and trajectory-optimise a raw planned path.
 
@@ -101,14 +102,20 @@ def _optimize(
         path: Raw planned waypoints, or ``None``.
         vehicle_cfg: ``vehicle`` sub-dict from the scenario YAML.
         step_size: Planner step size array used by the pruner.
+        enable_pruning: When ``True`` the path is pruned before optimisation.
+            When ``False`` (default) a copy of the original path is used
+            directly, skipping the pruning step.
 
     Returns:
         Tuple of ``(traj, duration, status_string)``.
     """
     if path is None or len(path) < 2:
         return None, 0.0, "no-path"
-    pruner = TrajectoryPruner(occ, step_size=step_size)
-    path = pruner.prune(path)
+    if enable_pruning:
+        pruner = TrajectoryPruner(occ, step_size=step_size)
+        path = pruner.prune(path)
+    else:
+        path = list(path)
     try:
         opt = TrajectoryOptimizer(
             occ,
@@ -240,11 +247,12 @@ def main(cfg: dict, save_path: str | None = None) -> None:
     sst_time = time.perf_counter() - t0
 
     _step_size = np.asarray(planner_cfg["step_size"], dtype=float)
+    _enable_pruning = bool(planner_cfg.get("enable_pruning", False))
     rrt_traj, rrt_dur, rrt_opt = _optimize(
-        occ, rrt_path, vehicle_cfg, _step_size
+        occ, rrt_path, vehicle_cfg, _step_size, enable_pruning=_enable_pruning
     )
     sst_traj, sst_dur, sst_opt = _optimize(
-        occ, sst_path, vehicle_cfg, _step_size
+        occ, sst_path, vehicle_cfg, _step_size, enable_pruning=_enable_pruning
     )
 
     logger.info("Simulating RRT* executed trajectory …")

--- a/src/arco/tools/map/city.yml
+++ b/src/arco/tools/map/city.yml
@@ -26,6 +26,11 @@ planner:
   # code expects normalized units (physical / step_size) but the value was
   # set as if it were meters, creating ~16 coarse cells that starved the tree.
   witness_radius: 0.5  # [] SST witness-cell half-width in normalized units
+  # Path pruning is a performance optimisation with a safety trade-off: it
+  # produces a smoother but riskier path by shortcutting intermediate
+  # waypoints.  To remain collision-free after pruning, all safety margins
+  # must be increased.  Disabled by default.
+  enable_pruning: false  # [] enable trajectory pruning (smooths path but requires larger safety margins)
 
 world:
   world_width: 1280.0  # [m] width of the world

--- a/src/arco/tools/map/occ.yml
+++ b/src/arco/tools/map/occ.yml
@@ -62,6 +62,11 @@ planner:
   sst_max_sample_count: 40000  # [] maximum number of SST samples
   witness_radius: 0.5            # [normalised steps] SST witness-cell deduplication radius
   cspace_grid_n: 120  # [] grid resolution for C-space sampling (n^3 points evaluated)
+  # Path pruning is a performance optimisation with a safety trade-off: it
+  # produces a smoother but riskier path by shortcutting intermediate
+  # waypoints.  To remain collision-free after pruning, all safety margins
+  # must be increased.  Disabled by default.
+  enable_pruning: false  # [] enable trajectory pruning (smooths path but requires larger safety margins)
 
 control:
   # Position PD — target: ωn ≈ 0.71 rad/s, ζ ≈ 0.59 → ~10 % overshoot.

--- a/src/arco/tools/map/ppp.yml
+++ b/src/arco/tools/map/ppp.yml
@@ -50,6 +50,11 @@ planner:
   rrt_max_sample_count: 10000  # [] maximum number of RRT* samples
   sst_max_sample_count: 8000  # [] maximum number of SST samples
   witness_radius: 0.7  # [normalised steps] SST witness-cell deduplication radius
+  # Path pruning is a performance optimisation with a safety trade-off: it
+  # produces a smoother but riskier path by shortcutting intermediate
+  # waypoints.  To remain collision-free after pruning, all safety margins
+  # must be increased.  Disabled by default.
+  enable_pruning: false  # [] enable trajectory pruning (smooths path but requires larger safety margins)
 
 # ---------------------------------------------------------------------------
 # Simulation / visualisation parameters

--- a/src/arco/tools/map/rr.yml
+++ b/src/arco/tools/map/rr.yml
@@ -46,6 +46,11 @@ planner:
   rrt_max_sample_count: 30000  # [] maximum number of RRT* samples
   sst_max_sample_count: 40000  # [] maximum number of SST samples
   witness_radius: 0.05  # [rad] SST witness cell radius (less than half the step size)
+  # Path pruning is a performance optimisation with a safety trade-off: it
+  # produces a smoother but riskier path by shortcutting intermediate
+  # waypoints.  To remain collision-free after pruning, all safety margins
+  # must be increased.  Disabled by default.
+  enable_pruning: false  # [] enable trajectory pruning (smooths path but requires larger safety margins)
 
 # ---------------------------------------------------------------------------
 # Simulator parameters

--- a/src/arco/tools/map/rrp.yml
+++ b/src/arco/tools/map/rrp.yml
@@ -82,6 +82,11 @@ planner:
 
   # Grid resolution for C-space sampling (n^3 points evaluated).
   cspace_grid_n: 80  # [] grid resolution for C-space sampling (n^3 points evaluated)
+  # Path pruning is a performance optimisation with a safety trade-off: it
+  # produces a smoother but riskier path by shortcutting intermediate
+  # waypoints.  To remain collision-free after pruning, all safety margins
+  # must be increased.  Disabled by default.
+  enable_pruning: false  # [] enable trajectory pruning (smooths path but requires larger safety margins)
 
 # ---------------------------------------------------------------------------
 # Simulator parameters

--- a/src/arco/tools/map/vehicle.yml
+++ b/src/arco/tools/map/vehicle.yml
@@ -26,6 +26,11 @@ planner:
   sst_max_sample_count: 4000  # [] maximum number of SST samples
   witness_radius: 0.8  # [normalised steps] SST witness-cell deduplication radius
   early_stop: true  # [] stop planning when first valid path is found
+  # Path pruning is a performance optimisation with a safety trade-off: it
+  # produces a smoother but riskier path by shortcutting intermediate
+  # waypoints.  To remain collision-free after pruning, all safety margins
+  # must be increased.  Disabled by default.
+  enable_pruning: false  # [] enable trajectory pruning (smooths path but requires larger safety margins)
 
 world:
   random_seed: 7  # [] random seed for world generation

--- a/src/arco/tools/simulator/scenes/occ.py
+++ b/src/arco/tools/simulator/scenes/occ.py
@@ -412,15 +412,20 @@ class OCCScene:
 
         from arco.planning import PlanningPipeline
 
-        pruner = TrajectoryPruner(
-            occ,
-            step_size=np.asarray(
-                self._planner_cfg.get("step_size", [1.0, 1.0, 0.1]),
-                dtype=float,
-            ),
-            collision_check_count=int(
-                self._planner_cfg.get("collision_check_count", 5)
-            ),
+        _enable_pruning = bool(self._planner_cfg.get("enable_pruning", False))
+        pruner = (
+            TrajectoryPruner(
+                occ,
+                step_size=np.asarray(
+                    self._planner_cfg.get("step_size", [1.0, 1.0, 0.1]),
+                    dtype=float,
+                ),
+                collision_check_count=int(
+                    self._planner_cfg.get("collision_check_count", 5)
+                ),
+            )
+            if _enable_pruning
+            else None
         )
         optimizer = TrajectoryOptimizer(
             occ,

--- a/src/arco/tools/simulator/scenes/ppp.py
+++ b/src/arco/tools/simulator/scenes/ppp.py
@@ -309,12 +309,19 @@ class PPPScene:
 
         from arco.planning import PlanningPipeline
 
-        pruner = TrajectoryPruner(
-            occ,
-            step_size=np.asarray(self._planner_cfg["step_size"], dtype=float),
-            collision_check_count=int(
-                self._planner_cfg["collision_check_count"]
-            ),
+        _enable_pruning = bool(self._planner_cfg.get("enable_pruning", False))
+        pruner = (
+            TrajectoryPruner(
+                occ,
+                step_size=np.asarray(
+                    self._planner_cfg["step_size"], dtype=float
+                ),
+                collision_check_count=int(
+                    self._planner_cfg["collision_check_count"]
+                ),
+            )
+            if _enable_pruning
+            else None
         )
         opt = TrajectoryOptimizer(
             occ,

--- a/src/arco/tools/simulator/scenes/rr.py
+++ b/src/arco/tools/simulator/scenes/rr.py
@@ -400,12 +400,17 @@ class RRScene:
         )
 
         step_size = np.asarray(self._planner_cfg["step_size"], dtype=float)
-        pruner = TrajectoryPruner(
-            occ,
-            step_size=step_size,
-            collision_check_count=int(
-                self._planner_cfg["collision_check_count"]
-            ),
+        _enable_pruning = bool(self._planner_cfg.get("enable_pruning", False))
+        pruner = (
+            TrajectoryPruner(
+                occ,
+                step_size=step_size,
+                collision_check_count=int(
+                    self._planner_cfg["collision_check_count"]
+                ),
+            )
+            if _enable_pruning
+            else None
         )
         optimizer = TrajectoryOptimizer(
             occ,

--- a/src/arco/tools/simulator/scenes/rrp.py
+++ b/src/arco/tools/simulator/scenes/rrp.py
@@ -446,12 +446,17 @@ class RRPScene:
         from arco.planning import PlanningPipeline
 
         step_size = np.asarray(self._planner_cfg["step_size"], dtype=float)
-        pruner = TrajectoryPruner(
-            occ,
-            step_size=step_size,
-            collision_check_count=int(
-                self._planner_cfg["collision_check_count"]
-            ),
+        _enable_pruning = bool(self._planner_cfg.get("enable_pruning", False))
+        pruner = (
+            TrajectoryPruner(
+                occ,
+                step_size=step_size,
+                collision_check_count=int(
+                    self._planner_cfg["collision_check_count"]
+                ),
+            )
+            if _enable_pruning
+            else None
         )
         optimizer = TrajectoryOptimizer(
             occ,

--- a/src/arco/tools/simulator/scenes/rrt.py
+++ b/src/arco/tools/simulator/scenes/rrt.py
@@ -146,13 +146,16 @@ class RRTScene(SimScene):
             if progress is not None:
                 progress("Optimizing trajectory", 3, _total)
             try:
-                pruner = TrajectoryPruner(
-                    self._occ,
-                    collision_check_count=int(
-                        self._cfg["collision_check_count"]
-                    ),
-                )
-                self._path = pruner.prune(self._path)
+                if bool(self._cfg.get("enable_pruning", False)):
+                    pruner = TrajectoryPruner(
+                        self._occ,
+                        collision_check_count=int(
+                            self._cfg["collision_check_count"]
+                        ),
+                    )
+                    self._path = pruner.prune(self._path)
+                else:
+                    self._path = list(self._path)
                 opt = TrajectoryOptimizer(
                     self._occ,
                     cruise_speed=_VEHICLE_CONFIG.cruise_speed,

--- a/src/arco/tools/simulator/scenes/sparse.py
+++ b/src/arco/tools/simulator/scenes/sparse.py
@@ -433,10 +433,15 @@ class CityScene:
         from arco.planning import PlanningPipeline
 
         cruise = self._vehicle_cfg.cruise_speed
-        pruner = TrajectoryPruner(
-            self._occ,
-            step_size=np.asarray(self._cfg["step_size"], dtype=float),
-            collision_check_count=int(self._cfg["collision_check_count"]),
+        _enable_pruning = bool(self._cfg.get("enable_pruning", False))
+        pruner = (
+            TrajectoryPruner(
+                self._occ,
+                step_size=np.asarray(self._cfg["step_size"], dtype=float),
+                collision_check_count=int(self._cfg["collision_check_count"]),
+            )
+            if _enable_pruning
+            else None
         )
         opt = TrajectoryOptimizer(
             self._occ,

--- a/src/arco/tools/simulator/scenes/sst.py
+++ b/src/arco/tools/simulator/scenes/sst.py
@@ -146,13 +146,16 @@ class SSTScene(SimScene):
             if progress is not None:
                 progress("Optimizing trajectory", 3, _total)
             try:
-                pruner = TrajectoryPruner(
-                    self._occ,
-                    collision_check_count=int(
-                        self._cfg["collision_check_count"]
-                    ),
-                )
-                self._path = pruner.prune(self._path)
+                if bool(self._cfg.get("enable_pruning", False)):
+                    pruner = TrajectoryPruner(
+                        self._occ,
+                        collision_check_count=int(
+                            self._cfg["collision_check_count"]
+                        ),
+                    )
+                    self._path = pruner.prune(self._path)
+                else:
+                    self._path = list(self._path)
                 opt = TrajectoryOptimizer(
                     self._occ,
                     cruise_speed=_VEHICLE_CONFIG.cruise_speed,

--- a/src/arco/tools/simulator/scenes/vehicle.py
+++ b/src/arco/tools/simulator/scenes/vehicle.py
@@ -169,12 +169,17 @@ class VehicleScene:
     ) -> tuple[list[np.ndarray], float, str]:
         if path is None or len(path) < 2 or self._occ is None:
             return [], 0.0, "no-path"
-        pruner = TrajectoryPruner(
-            self._occ,
-            step_size=np.asarray(self._planner["step_size"], dtype=float),
-            collision_check_count=int(self._planner["collision_check_count"]),
-        )
-        path = pruner.prune(path)
+        if bool(self._planner.get("enable_pruning", False)):
+            pruner = TrajectoryPruner(
+                self._occ,
+                step_size=np.asarray(self._planner["step_size"], dtype=float),
+                collision_check_count=int(
+                    self._planner["collision_check_count"]
+                ),
+            )
+            path = pruner.prune(path)
+        else:
+            path = list(path)
         try:
             opt = TrajectoryOptimizer(
                 self._occ,

--- a/tests/control/test_tracking_loop.py
+++ b/tests/control/test_tracking_loop.py
@@ -432,9 +432,14 @@ def test_repulsion_zero_when_gain_zero() -> None:
     """Repulsion is zero when repulsion_gain=0 regardless of proximity."""
     occ = _NearObstacleOccupancy(0.5, 0.0, clearance=2.0)
     vehicle = DubinsVehicle(
-        x=0.0, y=0.0, heading=0.0,
-        max_speed=5.0, min_speed=0.0,
-        max_turn_rate=4.0, max_acceleration=10.0, max_turn_rate_dot=10.0,
+        x=0.0,
+        y=0.0,
+        heading=0.0,
+        max_speed=5.0,
+        min_speed=0.0,
+        max_turn_rate=4.0,
+        max_acceleration=10.0,
+        max_turn_rate_dot=10.0,
     )
     loop = TrackingLoop(
         vehicle,
@@ -464,14 +469,24 @@ def test_step_repulsion_influences_turn_rate() -> None:
     # Two loops: one with repulsion toward a nearby obstacle, one without.
     occ = _NearObstacleOccupancy(0.3, 0.5, clearance=2.0)
     vehicle_rep = DubinsVehicle(
-        x=0.0, y=0.0, heading=0.0,
-        max_speed=5.0, min_speed=0.0,
-        max_turn_rate=4.0, max_acceleration=10.0, max_turn_rate_dot=10.0,
+        x=0.0,
+        y=0.0,
+        heading=0.0,
+        max_speed=5.0,
+        min_speed=0.0,
+        max_turn_rate=4.0,
+        max_acceleration=10.0,
+        max_turn_rate_dot=10.0,
     )
     vehicle_no = DubinsVehicle(
-        x=0.0, y=0.0, heading=0.0,
-        max_speed=5.0, min_speed=0.0,
-        max_turn_rate=4.0, max_acceleration=10.0, max_turn_rate_dot=10.0,
+        x=0.0,
+        y=0.0,
+        heading=0.0,
+        max_speed=5.0,
+        min_speed=0.0,
+        max_turn_rate=4.0,
+        max_acceleration=10.0,
+        max_turn_rate_dot=10.0,
     )
     loop_rep = TrackingLoop(
         vehicle_rep,

--- a/tests/guidance/test_controller.py
+++ b/tests/guidance/test_controller.py
@@ -21,4 +21,3 @@ def test_mpc_controller():
     ctrl = MPCController(horizon=5, dt=0.2)
     cmd = ctrl.control(0.0, 1.0)
     assert isinstance(cmd, float)
-

--- a/tests/middleware/test_bus.py
+++ b/tests/middleware/test_bus.py
@@ -11,7 +11,6 @@ import pytest
 from arco.middleware.bus import InMemoryBus
 from arco.middleware.types import GuidanceFrame, MappingFrame, PlanFrame
 
-
 # ---------------------------------------------------------------------------
 # Basic publish / subscribe
 # ---------------------------------------------------------------------------

--- a/tests/middleware/test_types.py
+++ b/tests/middleware/test_types.py
@@ -6,7 +6,6 @@ import time
 
 from arco.middleware.types import GuidanceFrame, MappingFrame, PlanFrame
 
-
 # ---------------------------------------------------------------------------
 # MappingFrame
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -12,7 +12,6 @@ from arco.middleware.bus import InMemoryBus
 from arco.middleware.types import MappingFrame
 from arco.pipeline.node import PipelineNode
 
-
 # ---------------------------------------------------------------------------
 # Concrete node fixtures
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/test_runner.py
+++ b/tests/pipeline/test_runner.py
@@ -14,7 +14,6 @@ from arco.middleware.types import GuidanceFrame, MappingFrame, PlanFrame
 from arco.pipeline.node import PipelineNode
 from arco.pipeline.runner import PipelineRunner
 
-
 # ---------------------------------------------------------------------------
 # Helper nodes and subscribers
 # ---------------------------------------------------------------------------

--- a/tests/planning/continuous/test_pruner.py
+++ b/tests/planning/continuous/test_pruner.py
@@ -31,7 +31,9 @@ def _straight_path(node_count=6):
 
 def test_construction_valid():
     occ = _free_occupancy()
-    pruner = TrajectoryPruner(occ, step_size=_STEP_2D, collision_check_count=10)
+    pruner = TrajectoryPruner(
+        occ, step_size=_STEP_2D, collision_check_count=10
+    )
     assert pruner.occupancy is occ
     assert pruner.collision_check_count == 10
     assert np.allclose(pruner.step_size, _STEP_2D)
@@ -65,19 +67,25 @@ def test_construction_negative_collision_check_count_raises():
 def test_construction_scalar_step_size_raises():
     """step_size must be a 1-D array; a scalar (0-D) is rejected."""
     occ = _free_occupancy()
-    with pytest.raises(ValueError, match="step_size must be a non-empty 1-D array"):
+    with pytest.raises(
+        ValueError, match="step_size must be a non-empty 1-D array"
+    ):
         TrajectoryPruner(occ, step_size=np.float64(1.0))
 
 
 def test_construction_zero_step_size_raises():
     occ = _free_occupancy()
-    with pytest.raises(ValueError, match="step_size elements must be strictly positive"):
+    with pytest.raises(
+        ValueError, match="step_size elements must be strictly positive"
+    ):
         TrajectoryPruner(occ, step_size=np.array([1.0, 0.0]))
 
 
 def test_construction_negative_step_size_raises():
     occ = _free_occupancy()
-    with pytest.raises(ValueError, match="step_size elements must be strictly positive"):
+    with pytest.raises(
+        ValueError, match="step_size elements must be strictly positive"
+    ):
         TrajectoryPruner(occ, step_size=np.array([1.0, -0.5]))
 
 
@@ -365,7 +373,9 @@ def test_segment_free_in_free_space():
 
 def test_segment_free_through_obstacle():
     occ = KDTreeOccupancy([[2.5, 2.5]], clearance=0.5)
-    pruner = TrajectoryPruner(occ, step_size=_STEP_2D, collision_check_count=20)
+    pruner = TrajectoryPruner(
+        occ, step_size=_STEP_2D, collision_check_count=20
+    )
     a = np.array([0.0, 0.0])
     b = np.array([5.0, 5.0])
     assert pruner._segment_free(a, b) is False
@@ -408,8 +418,9 @@ def test_n_step_2d_equal_steps():
     # D = [3.0, 3.0], L = [1.0, 1.0] → ratios = [3, 3] → n_step = 3
     # n_samples = max(3+1, …) = at least 4
     occ = KDTreeOccupancy([[1000.0, 1000.0]], clearance=0.01)
-    pruner = TrajectoryPruner(occ, step_size=np.array([1.0, 1.0]),
-                              collision_check_count=1)
+    pruner = TrajectoryPruner(
+        occ, step_size=np.array([1.0, 1.0]), collision_check_count=1
+    )
     a = np.array([0.0, 0.0])
     b = np.array([3.0, 3.0])
     # Just verify the segment is checked (no crash) and returns True (free).
@@ -423,8 +434,9 @@ def test_n_step_2d_asymmetric_step_sizes():
     The single non-zero ratio (0.5) gives n_step = 1 → at least 2 samples.
     """
     occ = KDTreeOccupancy([[1000.0, 1000.0]], clearance=0.01)
-    pruner = TrajectoryPruner(occ, step_size=np.array([1.0, 0.1]),
-                              collision_check_count=1)
+    pruner = TrajectoryPruner(
+        occ, step_size=np.array([1.0, 0.1]), collision_check_count=1
+    )
     a = np.array([0.0, 0.0])
     b = np.array([0.5, 0.0])
     assert pruner._segment_free(a, b) is True
@@ -439,8 +451,9 @@ def test_n_step_2d_psi_dim_dominates():
     """
     # Obstacle at (0.0, 0.25) — exactly at t=0.5 along the segment.
     occ = KDTreeOccupancy([[0.0, 0.25]], clearance=0.05)
-    pruner = TrajectoryPruner(occ, step_size=np.array([1.0, 0.1]),
-                              collision_check_count=1)
+    pruner = TrajectoryPruner(
+        occ, step_size=np.array([1.0, 0.1]), collision_check_count=1
+    )
     a = np.array([0.0, 0.0])
     b = np.array([0.0, 0.5])
     # With n_step = 5 (6 samples) the midpoint t=0.5 → (0, 0.25) is sampled.
@@ -527,9 +540,10 @@ def test_step_size_criterion_prevents_undersampling():
     """
     occ = KDTreeOccupancy([[2.5, 0.0]], clearance=0.1)
     step_size = np.array([0.5, 0.5])
-    pruner = TrajectoryPruner(occ, step_size=step_size, collision_check_count=1)
+    pruner = TrajectoryPruner(
+        occ, step_size=step_size, collision_check_count=1
+    )
     a = np.array([0.0, 0.0])
     b = np.array([5.0, 0.0])
     # With step-size criterion: 11 samples, t=0.5 → x=2.5 is sampled → False.
     assert pruner._segment_free(a, b) is False
-

--- a/tests/planning/continuous/test_telemetry.py
+++ b/tests/planning/continuous/test_telemetry.py
@@ -15,7 +15,6 @@ from arco.planning.continuous.telemetry import (
     write_telemetry,
 )
 
-
 # ---------------------------------------------------------------------------
 # StopCriterion.satisfied()
 # ---------------------------------------------------------------------------

--- a/tests/planning/test_pipeline.py
+++ b/tests/planning/test_pipeline.py
@@ -139,9 +139,7 @@ def test_run_planner_only_success():
 
 def test_run_planner_only_failure():
     planner = _AlwaysFailsPlanner()
-    result = PlanningPipeline(planner=planner).run(
-        np.zeros(2), np.ones(2)
-    )
+    result = PlanningPipeline(planner=planner).run(np.zeros(2), np.ones(2))
     assert result.planner_status == "no_path"
     assert result.raw_path is None
     assert result.trajectory is None
@@ -149,9 +147,7 @@ def test_run_planner_only_failure():
 
 def test_run_empty_path_treated_as_failure():
     planner = _EmptyPathPlanner()
-    result = PlanningPipeline(planner=planner).run(
-        np.zeros(2), np.ones(2)
-    )
+    result = PlanningPipeline(planner=planner).run(np.zeros(2), np.ones(2))
     assert result.planner_status == "no_path"
 
 
@@ -184,9 +180,9 @@ def test_run_with_pruner_pruner_receives_raw_path():
 
 def test_run_pruner_not_called_when_planning_fails():
     pruner = _RecordingPruner()
-    PlanningPipeline(
-        planner=_AlwaysFailsPlanner(), pruner=pruner
-    ).run(np.zeros(2), np.ones(2))
+    PlanningPipeline(planner=_AlwaysFailsPlanner(), pruner=pruner).run(
+        np.zeros(2), np.ones(2)
+    )
     assert len(pruner.calls) == 0
 
 
@@ -200,9 +196,9 @@ def test_run_with_optimizer_calls_optimizer():
     goal = np.array([5.0, 5.0])
     planner = _AlwaysSucceedsPlanner(start, goal)
     optimizer = _RecordingOptimizer()
-    result = PlanningPipeline(
-        planner=planner, optimizer=optimizer
-    ).run(start, goal)
+    result = PlanningPipeline(planner=planner, optimizer=optimizer).run(
+        start, goal
+    )
 
     assert len(optimizer.calls) == 1
     assert result.optimizer_success is True
@@ -215,9 +211,9 @@ def test_run_optimizer_receives_pruned_path():
     planner = _AlwaysSucceedsPlanner(start, goal)
     pruner = _RecordingPruner()
     optimizer = _RecordingOptimizer()
-    PlanningPipeline(
-        planner=planner, pruner=pruner, optimizer=optimizer
-    ).run(start, goal)
+    PlanningPipeline(planner=planner, pruner=pruner, optimizer=optimizer).run(
+        start, goal
+    )
 
     # Optimizer's first call should receive the pruner's output (same path here)
     assert len(optimizer.calls) == 1
@@ -225,9 +221,9 @@ def test_run_optimizer_receives_pruned_path():
 
 def test_run_optimizer_not_called_on_failure():
     optimizer = _RecordingOptimizer()
-    PlanningPipeline(
-        planner=_AlwaysFailsPlanner(), optimizer=optimizer
-    ).run(np.zeros(2), np.ones(2))
+    PlanningPipeline(planner=_AlwaysFailsPlanner(), optimizer=optimizer).run(
+        np.zeros(2), np.ones(2)
+    )
     assert len(optimizer.calls) == 0
 
 
@@ -266,9 +262,9 @@ def test_run_progress_callback_called_once_per_stage():
     def cb(stage: str, idx: int, total: int) -> None:
         calls.append((stage, idx, total))
 
-    PlanningPipeline(
-        planner=planner, pruner=pruner, optimizer=optimizer
-    ).run(start, goal, progress=cb)
+    PlanningPipeline(planner=planner, pruner=pruner, optimizer=optimizer).run(
+        start, goal, progress=cb
+    )
 
     assert len(calls) == 3
     stages = [c[0] for c in calls]

--- a/tests/tools/test_enable_pruning.py
+++ b/tests/tools/test_enable_pruning.py
@@ -1,0 +1,221 @@
+"""Tests for the enable_pruning configuration flag.
+
+Verifies that:
+- All map YAML files default ``enable_pruning`` to ``False``.
+- When the flag is disabled the pruned path is a copy of the original raw
+  path (not None, not shorter).
+- When the flag is enabled a ``TrajectoryPruner`` is used and may produce a
+  shorter path.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+import yaml
+
+_REPO = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+sys.path.insert(0, os.path.join(_REPO, "src"))
+
+from arco.mapping import KDTreeOccupancy
+from arco.planning.continuous import TrajectoryPruner
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MAP_DIR = os.path.join(_REPO, "src", "arco", "tools", "map")
+
+# YAML files that contain a `planner` section with `enable_pruning`.
+_PRUNER_YAMLS = [
+    "city.yml",
+    "ppp.yml",
+    "rr.yml",
+    "occ.yml",
+    "rrp.yml",
+    "vehicle.yml",
+]
+
+
+def _load_planner_cfg(name: str) -> dict:
+    path = os.path.join(_MAP_DIR, name)
+    with open(path) as fh:
+        cfg = yaml.safe_load(fh)
+    return cfg.get("planner", {})
+
+
+def _free_occ() -> KDTreeOccupancy:
+    return KDTreeOccupancy([[1000.0, 1000.0]], clearance=0.1)
+
+
+def _collinear_path(n: int = 8) -> list[np.ndarray]:
+    return [np.array([float(i), 0.0]) for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# 1. YAML defaults – enable_pruning must be False in every map file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("yml_name", _PRUNER_YAMLS)
+def test_yaml_enable_pruning_default_is_false(yml_name: str) -> None:
+    """All map YAML planner sections must default ``enable_pruning`` to False."""
+    planner_cfg = _load_planner_cfg(yml_name)
+    assert (
+        "enable_pruning" in planner_cfg
+    ), f"{yml_name}: missing 'enable_pruning' key in [planner] section"
+    assert planner_cfg["enable_pruning"] is False, (
+        f"{yml_name}: 'enable_pruning' should be False by default, "
+        f"got {planner_cfg['enable_pruning']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Disabled behaviour – pruned path is an identical copy of the raw path
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_pruning_direct_pattern_returns_copy() -> None:
+    """Direct-pruner scene pattern: disabled → path is a list copy, not None."""
+    raw_path = _collinear_path(6)
+    enable_pruning = False
+
+    # Replicate the direct-pruner scene logic.
+    if enable_pruning:
+        occ = _free_occ()
+        pruner = TrajectoryPruner(occ, step_size=np.array([1.0, 1.0]))
+        pruned = pruner.prune(raw_path)
+    else:
+        pruned = list(raw_path)
+
+    assert pruned is not raw_path, "pruned must be a new list object"
+    assert len(pruned) == len(raw_path)
+    for a, b in zip(pruned, raw_path):
+        assert np.allclose(a, b)
+
+
+def test_disabled_pruning_pipeline_pattern_returns_copy() -> None:
+    """Pipeline scene pattern: pruner=None → fallback copy of the raw path."""
+    raw_path = _collinear_path(6)
+    enable_pruning = False
+
+    # Replicate the PlanningPipeline scene logic.
+    pruner = (
+        TrajectoryPruner(_free_occ(), step_size=np.array([1.0, 1.0]))
+        if enable_pruning
+        else None
+    )
+    pruned = pruner.prune(raw_path) if pruner is not None else list(raw_path)
+
+    assert pruner is None
+    assert pruned is not raw_path
+    assert len(pruned) == len(raw_path)
+    for a, b in zip(pruned, raw_path):
+        assert np.allclose(a, b)
+
+
+def test_disabled_pruning_preserves_every_waypoint() -> None:
+    """With pruning disabled no waypoints are dropped or reordered."""
+    raw_path = [np.array([float(i), float(i % 3)]) for i in range(10)]
+    pruned = list(raw_path)
+
+    assert len(pruned) == len(raw_path)
+    for orig, copy_ in zip(raw_path, pruned):
+        assert np.allclose(orig, copy_)
+
+
+# ---------------------------------------------------------------------------
+# 3. Enabled behaviour – TrajectoryPruner is used and may reduce the path
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_pruning_direct_pattern_creates_pruner() -> None:
+    """When enabled, a TrajectoryPruner instance is created and used."""
+    raw_path = _collinear_path(8)
+    enable_pruning = True
+    step_size = np.array([1.0, 1.0])
+    occ = _free_occ()
+
+    pruner = (
+        TrajectoryPruner(occ, step_size=step_size) if enable_pruning else None
+    )
+
+    assert pruner is not None
+    pruned = pruner.prune(raw_path) if pruner is not None else list(raw_path)
+    # In free space the pruner collapses a collinear path to 2 nodes.
+    assert len(pruned) <= len(raw_path)
+    assert np.allclose(pruned[0], raw_path[0])
+    assert np.allclose(pruned[-1], raw_path[-1])
+
+
+def test_enabled_pruning_shortens_collinear_path_in_free_space() -> None:
+    """Collinear path in free space is reduced to start+goal when pruning enabled."""
+    raw_path = _collinear_path(10)
+    occ = _free_occ()
+    pruner = TrajectoryPruner(occ, step_size=np.array([1.0, 1.0]))
+    pruned = pruner.prune(raw_path)
+
+    assert len(pruned) == 2
+    assert np.allclose(pruned[0], raw_path[0])
+    assert np.allclose(pruned[-1], raw_path[-1])
+
+
+def test_enabled_pruning_result_shorter_than_disabled() -> None:
+    """Enabled pruning yields fewer waypoints than disabled (copy) on a collinear path."""
+    raw_path = _collinear_path(10)
+    occ = _free_occ()
+
+    # Enabled.
+    pruner = TrajectoryPruner(occ, step_size=np.array([1.0, 1.0]))
+    pruned_enabled = pruner.prune(raw_path)
+
+    # Disabled.
+    pruned_disabled = list(raw_path)
+
+    assert len(pruned_enabled) < len(pruned_disabled)
+
+
+# ---------------------------------------------------------------------------
+# 4. Flag propagation via config dict (mirrors scene/example read pattern)
+# ---------------------------------------------------------------------------
+
+
+def test_cfg_get_returns_false_when_key_absent() -> None:
+    """Scenes use cfg.get('enable_pruning', False); missing key → False."""
+    cfg: dict = {}
+    result = bool(cfg.get("enable_pruning", False))
+    assert result is False
+
+
+def test_cfg_get_returns_false_when_key_is_false() -> None:
+    cfg = {"enable_pruning": False}
+    result = bool(cfg.get("enable_pruning", False))
+    assert result is False
+
+
+def test_cfg_get_returns_true_when_key_is_true() -> None:
+    cfg = {"enable_pruning": True}
+    result = bool(cfg.get("enable_pruning", False))
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# 5. astar.yml must not have enable_pruning (no pruner used there)
+# ---------------------------------------------------------------------------
+
+
+def test_astar_yml_has_no_enable_pruning_key() -> None:
+    """astar.yml uses discrete A* — no TrajectoryPruner, no enable_pruning."""
+    path = os.path.join(_MAP_DIR, "astar.yml")
+    with open(path) as fh:
+        cfg = yaml.safe_load(fh)
+    planner_cfg = cfg.get("planner", {})
+    assert "enable_pruning" not in planner_cfg, (
+        "astar.yml should not have an 'enable_pruning' key "
+        "(no TrajectoryPruner is used for discrete A*)"
+    )


### PR DESCRIPTION
Add an `enable_pruning` boolean flag (default: false) to the `planner` section of all six map YAML files (city, ppp, rr, occ, rrp, vehicle) in both map/ and src/arco/tools/map/.

When disabled (the default), the pruned path is a shallow copy of the original raw path — no waypoints are dropped.  When enabled, a TrajectoryPruner instance is created and used to shortcut intermediate waypoints.

The flag is documented in every YAML as a performance optimisation with a safety trade-off: pruning generates a smoother but riskier path, and all safety margins must be increased to keep the result collision-free.

Source changes:
- tools/examples/ppp.py, rr.py, rrp.py, vehicle.py: read enable_pruning from planner config; build pruner conditionally.
- tools/simulator/scenes/rrt.py, sst.py, vehicle.py: guard direct pruner call with the flag; fall back to list(path) when disabled.
- tools/simulator/scenes/ppp.py, rr.py, occ.py, rrp.py, sparse.py: pass pruner=None to PlanningPipeline when disabled; existing fallback (pruned_path if pruned_path is not None else path) handles None correctly.

Tests added:
- tests/tools/test_enable_pruning.py: 16 tests covering YAML defaults, disabled-copy behaviour (both direct and pipeline patterns), enabled shortening behaviour, cfg.get() propagation, and astar.yml exclusion.