### PR TITLE
ci(release): cut Release Videos wall-clock (preview city + fast-record)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
   # One parallel job per simulator scenario.  Each job generates a single
   # MP4 and uploads it as a workflow artifact so the publish job can
   # collect and attach all files to the release in one step.
+  #
+  # Wall-clock ≈ max(matrix) ≈ city.  Release mode uses the reduced-budget
+  # city preview map + --fast-record (skip tree-reveal pacing).
   # -----------------------------------------------------------------------
   generate-video:
     name: Generate ${{ matrix.scenario }} video
@@ -30,23 +33,37 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install system dependencies
         run: |
           sudo apt-get update -y
           sudo apt-get install -y ffmpeg xvfb libgl1 libglib2.0-0
 
-      - name: Install package with simulator and MPC dependencies
-        # mpc (CasADi) is required when map YAMLs set simulator.tracker: mpc
-        # (vehicle, ppp, rrp). Without it, arcosim raises ImportError at race start.
-        run: pip install -e ".[tools,pygame,mpc]"
+      - name: Install package with simulator dependencies
+        # CasADi (mpc) only for scenarios whose map YAML sets tracker: mpc.
+        run: |
+          set -euo pipefail
+          case "${{ matrix.scenario }}" in
+            city|vehicle|ppp|rrp)
+              pip install -e ".[tools,pygame,mpc]"
+              ;;
+            *)
+              pip install -e ".[tools,pygame]"
+              ;;
+          esac
 
       - name: Generate video
+        # Duration 30 s with --fast-record ≈ the old 60 s clips that spent
+        # half the budget on cheap tree-reveal frames.  All frames are now
+        # race/tracking (MPC-heavy for city/vehicle/ppp/rrp).
         run: |
           bash scripts/generate_videos.sh \
+            --release \
             --only ${{ matrix.scenario }} \
             --out-dir /tmp/sim_videos \
-            --duration 60
+            --duration 30
 
       - name: Upload video artifact
         uses: actions/upload-artifact@v4

--- a/docs/STACK.md
+++ b/docs/STACK.md
@@ -85,7 +85,7 @@ Run the same gates CI uses:
 | `scripts/check_formatting.sh` | black + isort (blocking), pydocstyle (warning) |
 | `scripts/run_tests.sh` | pytest unit tests |
 | `scripts/run_smoke_test.sh <scenario>` | short headless `arcosim` recording |
-| `scripts/generate_videos.sh` | full-length simulation videos |
+| `scripts/generate_videos.sh` | full-length simulation videos (`--release` for CI) |
 
 ```bash
 bash scripts/check_formatting.sh

--- a/docs/VISUALIZATION.md
+++ b/docs/VISUALIZATION.md
@@ -37,6 +37,9 @@ arcosim map/city.yml --record output/city.mp4
 # Limit recording duration
 arcosim map/city.yml --record output/city.mp4 --record-duration 30
 
+# Fast headless recording: skip animated planner-tree reveal
+arcosim map/city.yml -o output/city.mp4 -d 60 --fast-record
+
 # Static image mode — opens matplotlib window
 arcosim map/city.yml --image
 
@@ -58,6 +61,20 @@ arcosim map/city.yml --static --record output/city.png
 | `rr`     | RR robot arm kinematics |
 | `rrp`    | RRP robot arm kinematics |
 | `vehicle`| Vehicle trajectory with tracking controller |
+
+### Release / CI video generation
+
+`scripts/generate_videos.sh --release` (used by `.github/workflows/release.yml`):
+
+- Remaps logical scenario `city` → `map/city_mpc_preview.yml` (reduced RRT*/SST/A*
+  sample budgets) while still writing `arcosim_city.mp4`.
+- Passes `--fast-record` so recordings skip tree-reveal pacing and spend the
+  duration budget on the race / tracking phase.
+- Uses **30 s** clips (not 60 s): with fast-record every frame is
+  race/tracking; 30 s matches the race portion of the former 60 s videos
+  that spent ~half the time revealing trees.
+- Caches pip and installs CasADi (`arco[mpc]`) only for scenarios whose YAML
+  sets `tracker: mpc` (`city`, `vehicle`, `ppp`, `rrp`).
 
 City race notes when `simulator.tracker: mpc`:
 

--- a/map/city_mpc_preview.yml
+++ b/map/city_mpc_preview.yml
@@ -1,5 +1,7 @@
-# Preview map for MPC city race video (reduced planner budgets).
-# Same world/tracker as city.yml; not used by release matrix.
+# Preview / release map for the city race (reduced planner budgets).
+# Same world/tracker as city.yml.  Release Videos uses this file via
+# ``scripts/generate_videos.sh --release`` while publishing as
+# ``arcosim_city.mp4`` (see .github/workflows/release.yml).
 scenario: city
 planner:
   step_size:

--- a/scripts/generate_videos.sh
+++ b/scripts/generate_videos.sh
@@ -14,7 +14,12 @@
 #   --out-dir <path>        Output directory (default: /tmp/arco_videos)
 #   --duration <seconds>    Recording duration per scenario (default: 60)
 #   --only <name,...>       Comma-separated list of scenario names to run
-#                           (default: all). E.g. --only ppp,rr
+#                           (default: all primary scenarios). E.g. --only ppp,rr
+#   --release               Release mode: use reduced city planner budgets
+#                           (map/city_mpc_preview.yml → arcosim_city.mp4) and
+#                           pass --fast-record to skip tree-reveal pacing.
+#   --dry-run               Print the resolved map / output / flags and exit
+#                           without running arcosim (for CI / script tests).
 #
 # Exit code: 0 = all pass, 1 = at least one failure.
 
@@ -26,6 +31,12 @@ cd "$REPO_ROOT"
 OUT_DIR="/tmp/arco_videos"
 DURATION=120  # seconds (2 minutes)
 ONLY=""
+RELEASE=0
+DRY_RUN=0
+
+# Primary release / smoke scenario names (basename of map/*.yml).
+# Preview / alternate maps are not listed here; --release remaps city.
+PRIMARY_SCENARIOS=(astar city ppp rr vehicle rrp occ)
 
 # Parse optional args
 while [[ $# -gt 0 ]]; do
@@ -33,6 +44,8 @@ while [[ $# -gt 0 ]]; do
         --out-dir)  OUT_DIR="$2"; shift 2 ;;
         --duration) DURATION="$2"; shift 2 ;;
         --only)     ONLY="$2"; shift 2 ;;
+        --release)  RELEASE=1; shift ;;
+        --dry-run)  DRY_RUN=1; shift ;;
         *) echo "Unknown arg: $1"; exit 1 ;;
     esac
 done
@@ -42,30 +55,52 @@ mkdir -p "$OUT_DIR"
 echo "=== Simulation video generation (arcosim, headless) ==="
 echo "Output directory : $OUT_DIR"
 echo "Duration per clip: ${DURATION} s"
+[ "$RELEASE" -eq 1 ] && echo "Mode             : release (city preview map + fast-record)"
 [ -n "$ONLY" ] && echo "Scenarios filter : $ONLY"
 
-MAP_DIR="$REPO_ROOT/map"
-ALL_SCENARIOS=$(find "$MAP_DIR" -name "*.yml" | sort)
+# Resolve which logical scenario names to run.
+SCENARIOS=()
+if [ -n "$ONLY" ]; then
+    IFS=',' read -ra SCENARIOS <<< "$ONLY"
+else
+    SCENARIOS=("${PRIMARY_SCENARIOS[@]}")
+fi
 
 FAILED=0
-for CFG in $ALL_SCENARIOS; do
-    NAME="$(basename "$CFG" .yml)"
+for NAME in "${SCENARIOS[@]}"; do
+    NAME="$(echo "$NAME" | tr -d '[:space:]')"
+    [ -z "$NAME" ] && continue
 
-    # Apply --only filter if provided
-    if [ -n "$ONLY" ]; then
-        IFS=',' read -ra FILTER <<< "$ONLY"
-        MATCH=false
-        for F in "${FILTER[@]}"; do
-            [ "$F" = "$NAME" ] && MATCH=true && break
-        done
-        [ "$MATCH" = false ] && continue
+    # Release city uses the reduced-budget preview map but keeps the public
+    # artifact name arcosim_city.mp4 expected by publish_release_videos.sh.
+    if [ "$RELEASE" -eq 1 ] && [ "$NAME" = "city" ]; then
+        CFG="$REPO_ROOT/map/city_mpc_preview.yml"
+    else
+        CFG="$REPO_ROOT/map/${NAME}.yml"
+    fi
+
+    if [ ! -f "$CFG" ]; then
+        echo "❌  $NAME: map not found → $CFG"
+        FAILED=$((FAILED + 1))
+        continue
     fi
 
     OUT="$OUT_DIR/arcosim_${NAME}.mp4"
+    EXTRA_ARGS=()
+    if [ "$RELEASE" -eq 1 ]; then
+        EXTRA_ARGS+=(--fast-record)
+    fi
+
     echo "--- $NAME ($CFG) ---"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "DRY-RUN: arcosim $CFG -o $OUT -d $DURATION ${EXTRA_ARGS[*]:-}"
+        continue
+    fi
+
     if SDL_AUDIODRIVER=dummy xvfb-run -a arcosim "$CFG" \
            -o "$OUT" \
-           -d "$DURATION"; then
+           -d "$DURATION" \
+           "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"; then
         echo "✅  $NAME: OK  →  $OUT"
     else
         echo "❌  $NAME: FAILED"
@@ -81,4 +116,3 @@ else
     echo "❌  $FAILED video(s) FAILED"
     exit 1
 fi
-

--- a/src/arco/simulator/__main__.py
+++ b/src/arco/simulator/__main__.py
@@ -2,7 +2,7 @@
 
 Usage::
 
-    arcosim path/to/scenario.yml [--record PATH] [--record-duration SECONDS]]
+    arcosim path/to/scenario.yml [-o PATH] [-d SECONDS] [--fast-record]
     arcosim path/to/scenario.yml --static [--record PATH]
 
 Requires the ``tools`` optional dependency group::
@@ -66,8 +66,20 @@ def _load_map(path: str) -> dict[str, Any]:
 
 
 def _dispatch(
-    cfg: dict[str, Any], save_path: str | None, record_duration: float
+    cfg: dict[str, Any],
+    save_path: str | None,
+    record_duration: float,
+    *,
+    fast_record: bool = False,
 ) -> None:
+    if fast_record:
+        # Scenes read simulator.fast_record to skip tree-reveal pacing in
+        # headless release / CI recordings (see docs/VISUALIZATION.md).
+        sim = cfg.setdefault("simulator", {})
+        if not isinstance(sim, dict):
+            cfg["simulator"] = {"fast_record": True}
+        else:
+            sim["fast_record"] = True
     scenario = cfg["scenario"]
     submodule = getattr(simulator, scenario, None)
     if not submodule:
@@ -115,6 +127,15 @@ def parse_args() -> argparse.Namespace:
         default=360.0,
         help="Maximum recording length in seconds (default: 360 s).",
     )
+    parser.add_argument(
+        "--fast-record",
+        action="store_true",
+        help=(
+            "Headless release mode: skip animated planner-tree reveal and "
+            "spend the recording budget on the race / tracking phase.  "
+            "Sets simulator.fast_record in the loaded YAML config."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -124,17 +145,17 @@ def main() -> None:
     Parses CLI arguments, validates the scenario YAML file, and dispatches
     to the matching simulator handler.
 
-    Unknown flags are forwarded verbatim to the underlying simulator so that
-    scenario-specific options (e.g. ``--fps``, ``--dt``, ``--camera``) can be
-    passed through without needing to be declared here.
-
     Raises:
         SystemExit: On any validation error or missing dependencies.
     """
-    # Delegate to the appropriate handler
     args = parse_args()
     cfg = _load_map(args.scenario_file)
-    _dispatch(cfg, args.output, args.record_duration)
+    _dispatch(
+        cfg,
+        args.output,
+        args.record_duration,
+        fast_record=bool(args.fast_record),
+    )
 
 
 if __name__ == "__main__":

--- a/src/arco/simulator/__main__.py
+++ b/src/arco/simulator/__main__.py
@@ -18,8 +18,6 @@ import os
 import sys
 from typing import Any
 
-import arco.simulator.main as simulator
-
 logger = logging.getLogger(__name__)
 
 # Optional-dependency guard for yaml
@@ -65,6 +63,21 @@ def _load_map(path: str) -> dict[str, Any]:
     return cfg
 
 
+def _apply_fast_record(cfg: dict[str, Any]) -> None:
+    """Set ``simulator.fast_record`` on a loaded scenario config.
+
+    Args:
+        cfg: Mutable scenario dictionary (must already contain ``scenario``).
+    """
+    # Scenes read simulator.fast_record to skip tree-reveal pacing in
+    # headless release / CI recordings (see docs/VISUALIZATION.md).
+    sim = cfg.setdefault("simulator", {})
+    if not isinstance(sim, dict):
+        cfg["simulator"] = {"fast_record": True}
+    else:
+        sim["fast_record"] = True
+
+
 def _dispatch(
     cfg: dict[str, Any],
     save_path: str | None,
@@ -73,13 +86,12 @@ def _dispatch(
     fast_record: bool = False,
 ) -> None:
     if fast_record:
-        # Scenes read simulator.fast_record to skip tree-reveal pacing in
-        # headless release / CI recordings (see docs/VISUALIZATION.md).
-        sim = cfg.setdefault("simulator", {})
-        if not isinstance(sim, dict):
-            cfg["simulator"] = {"fast_record": True}
-        else:
-            sim["fast_record"] = True
+        _apply_fast_record(cfg)
+    # Lazy import: scenario mains pull pygame/OpenGL.  Keeping this inside
+    # dispatch lets unit tests import parse_args / _apply_fast_record without
+    # the display stack (headless CI unit jobs omit pygame).
+    import arco.simulator.main as simulator
+
     scenario = cfg["scenario"]
     submodule = getattr(simulator, scenario, None)
     if not submodule:
@@ -118,7 +130,10 @@ def parse_args() -> argparse.Namespace:
         "--output",
         "-o",
         default=None,
-        help="Destination of the output file. If not provided, display interactively (default: none).",
+        help=(
+            "Destination of the output file. If not provided, display "
+            "interactively (default: none)."
+        ),
     )
     parser.add_argument(
         "--record-duration",

--- a/src/arco/simulator/main/astar.py
+++ b/src/arco/simulator/main/astar.py
@@ -39,6 +39,9 @@ from arco.simulator.sim import run_sim
 
 def main(cfg: dict, save_path: str | None, sim_duration: float) -> None:
     sim_cfg = load_config("simulator")
+    yaml_sim = cfg.get("simulator", {})
+    if not isinstance(yaml_sim, dict):
+        yaml_sim = {}
     scene = AStarScene(
         cfg.get("graph", {}),
         cfg.get("vehicle", {}),
@@ -51,4 +54,5 @@ def main(cfg: dict, save_path: str | None, sim_duration: float) -> None:
         zoom=0.5,
         record=save_path,
         record_duration=sim_duration,
+        fast_record=bool(yaml_sim.get("fast_record", False)),
     )

--- a/src/arco/simulator/main/city.py
+++ b/src/arco/simulator/main/city.py
@@ -213,6 +213,7 @@ def run_race(
     dt: float = 0.1,
     record: str = "",
     record_duration: float = 90.0,
+    fast_record: bool = False,
 ) -> None:
     """Run the three-vehicle cul-de-sac race.
 
@@ -230,9 +231,21 @@ def run_race(
         dt: Simulation timestep in seconds.
         record: Output MP4 file path.  Empty string means interactive mode.
         record_duration: Maximum headless recording length in seconds.
+        fast_record: When recording, skip animated tree reveal and start the
+            race immediately so the duration budget is spent on tracking.
     """
     recording = bool(record)
     max_record_frames = int(fps * record_duration)
+    # Also honor YAML ``simulator.fast_record`` when the caller did not pass
+    # the flag explicitly (arcosim --fast-record mutates the scene config).
+    sim_cfg_early = getattr(scene, "_sim_cfg", None)
+    if not isinstance(sim_cfg_early, dict):
+        sim_cfg_early = (getattr(scene, "_cfg", {}) or {}).get("simulator", {})
+    if not isinstance(sim_cfg_early, dict):
+        sim_cfg_early = {}
+    fast_record = bool(fast_record) or (
+        recording and bool(sim_cfg_early.get("fast_record", False))
+    )
 
     # OpenGL requires a real (or virtual) display.  For headless recording
     # use xvfb-run.
@@ -308,12 +321,15 @@ def run_race(
     )
 
     # Pacing: reveal all trees in parallel, finishing together at ~half-time.
+    # Fast-record spends the whole duration on racing (no reveal budget).
     half_frames = (
         max(1, max_record_frames // 2) if recording else max(1, fps * 8)
     )
     nodes_per_frame = max(
-        1, max(rrt_total, sst_total, astar_total) // half_frames
+        1, max(rrt_total, sst_total, astar_total, 1) // half_frames
     )
+    if fast_record:
+        nodes_per_frame = max(rrt_total, sst_total, astar_total, 1)
 
     # ---------------------------------------------------------------------------
     # Mutable simulation state
@@ -329,6 +345,11 @@ def run_race(
     sst_revealed = 0
     astar_revealed = 0
     hold = 0
+    if fast_record:
+        rrt_revealed = rrt_total
+        sst_revealed = sst_total
+        astar_revealed = astar_total
+        _bg_stage_idx = len(_bg_stages) - 1
 
     rrt_vehicle = None
     sst_vehicle = None
@@ -352,9 +373,7 @@ def run_race(
 
     # CityScene stores simulator config in _sim_cfg; VehicleScene keeps
     # the full YAML under _cfg["simulator"].
-    sim_cfg = getattr(scene, "_sim_cfg", None)
-    if not isinstance(sim_cfg, dict):
-        sim_cfg = (getattr(scene, "_cfg", {}) or {}).get("simulator", {})
+    sim_cfg = sim_cfg_early
     tracker_mode = str(sim_cfg.get("tracker", "pure_pursuit"))
 
     def _start_racing() -> None:
@@ -507,12 +526,17 @@ def run_race(
                     )
                     if both_done:
                         hold += 1
-                        if hold >= _HOLD_FRAMES or (
-                            recording and record_frames >= half_frames
+                        if (
+                            fast_record
+                            or hold >= _HOLD_FRAMES
+                            or (recording and record_frames >= half_frames)
                         ):
                             phase = "racing"
                             _start_racing()
-                            logger.info("Switched to racing phase.")
+                            logger.info(
+                                "Switched to racing phase%s.",
+                                " (fast-record)" if fast_record else "",
+                            )
 
                 elif phase == "racing":
                     race_time += dt
@@ -853,10 +877,13 @@ def run_race(
 
 def main(cfg: dict, save_path: str | None, sim_duration: float) -> None:
     sim_cfg = load_config("simulator")
+    scene_sim_cfg = cfg.get("simulator", {})
+    if not isinstance(scene_sim_cfg, dict):
+        scene_sim_cfg = {}
     scene = CityScene(
         cfg.get("planner", {}),
         cfg.get("world", {}),
-        sim_cfg=cfg.get("simulator", {}),
+        sim_cfg=scene_sim_cfg,
     )
     run_race(
         scene,
@@ -864,4 +891,5 @@ def main(cfg: dict, save_path: str | None, sim_duration: float) -> None:
         dt=sim_cfg["timestep"],
         record=save_path,
         record_duration=sim_duration,
+        fast_record=bool(scene_sim_cfg.get("fast_record", False)),
     )

--- a/src/arco/simulator/main/vehicle.py
+++ b/src/arco/simulator/main/vehicle.py
@@ -27,10 +27,14 @@ def main(cfg: dict, save_path: str | None, sim_duration: float) -> None:
     """Parse CLI arguments and launch the vehicle benchmark race."""
     sim_cfg = load_config("simulator")
     scene = VehicleScene(cfg)
+    yaml_sim = cfg.get("simulator", {})
+    if not isinstance(yaml_sim, dict):
+        yaml_sim = {}
     run_race(
         scene,
         fps=sim_cfg["fps"],
         dt=sim_cfg["timestep"],
         record=save_path,
         record_duration=sim_duration,
+        fast_record=bool(yaml_sim.get("fast_record", False)),
     )

--- a/src/arco/simulator/sim/loop.py
+++ b/src/arco/simulator/sim/loop.py
@@ -134,6 +134,7 @@ def run_sim(
     zoom: bool = False,
     record: str = "",
     record_duration: float = 60.0,
+    fast_record: bool = False,
 ) -> None:
     """Run the unified two-phase simulator loop for *scene*.
 
@@ -159,9 +160,12 @@ def run_sim(
         record: Output MP4 file path for a headless recording.  Empty string
             means interactive mode (opens a window).
         record_duration: Maximum recording length in seconds.
+        fast_record: When recording, skip animated background reveal and start
+            tracking immediately.
     """
     recording = bool(record)
     max_record_frames = int(fps * record_duration)
+    fast_record = bool(fast_record) and recording
 
     # OpenGL requires a real (or virtual) display — do not set
     # SDL_VIDEODRIVER=dummy.  For headless recording use xvfb-run.
@@ -207,6 +211,8 @@ def run_sim(
     nodes_per_frame = (
         max(1, background_total // half_frames) if background_total > 0 else 0
     )
+    if fast_record and background_total > 0:
+        nodes_per_frame = background_total
 
     # Camera filter starts at the first waypoint (or world origin).
     waypoints = scene.waypoints
@@ -248,6 +254,8 @@ def run_sim(
     phase = "background" if background_total > 0 else "tracking"
     revealed = 0
     hold = 0
+    if fast_record and background_total > 0:
+        revealed = background_total
 
     vehicle = None
     veh_loop = None
@@ -364,13 +372,18 @@ def run_sim(
                         )
                     else:
                         hold += 1
-                        transition = hold >= _HOLD_FRAMES or (
-                            recording and record_frames >= half_frames
+                        transition = (
+                            fast_record
+                            or hold >= _HOLD_FRAMES
+                            or (recording and record_frames >= half_frames)
                         )
                         if transition:
                             phase = "tracking"
                             _start_tracking()
-                            logger.info("Switched to tracking phase.")
+                            logger.info(
+                                "Switched to tracking phase%s.",
+                                " (fast-record)" if fast_record else "",
+                            )
                 elif phase == "tracking" and not veh_finished:
                     if vehicle is not None and veh_loop is not None:
                         veh_loop.step(waypoints, dt=dt)

--- a/tests/scripts/test_generate_videos_release.py
+++ b/tests/scripts/test_generate_videos_release.py
@@ -1,0 +1,34 @@
+"""Tests for scripts/generate_videos.sh release-mode remapping."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_generate_videos_release_dry_run_remaps_city() -> None:
+    """Release mode must use city_mpc_preview.yml and pass --fast-record."""
+    repo = Path(__file__).resolve().parents[2]
+    script = repo / "scripts" / "generate_videos.sh"
+    result = subprocess.run(
+        [
+            "bash",
+            str(script),
+            "--release",
+            "--only",
+            "city",
+            "--dry-run",
+            "--duration",
+            "60",
+            "--out-dir",
+            "/tmp/arco_videos_test",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    out = result.stdout
+    assert "city_mpc_preview.yml" in out
+    assert "arcosim_city.mp4" in out
+    assert "--fast-record" in out
+    assert "Mode             : release" in out

--- a/tests/simulator/test_arcosim_cli.py
+++ b/tests/simulator/test_arcosim_cli.py
@@ -1,8 +1,13 @@
-"""Tests for the arcosim CLI fast-record / dispatch wiring."""
+"""Tests for the arcosim CLI fast-record / dispatch wiring.
+
+These tests must not import pygame: CI unit jobs install ``arco`` without the
+display extras.  ``arco.simulator.__main__`` lazy-imports scenario mains.
+"""
 
 from __future__ import annotations
 
 import sys
+import types
 from typing import Any
 
 import pytest
@@ -31,12 +36,18 @@ def test_parse_args_fast_record_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     assert args.fast_record is True
 
 
+def test_apply_fast_record_sets_simulator_flag() -> None:
+    cfg: dict[str, Any] = {"scenario": "city", "planner": {}}
+    arcosim_main._apply_fast_record(cfg)
+    assert cfg["simulator"]["fast_record"] is True
+
+
 def test_dispatch_sets_simulator_fast_record(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, Any] = {}
 
-    class _FakeModule:
+    class _FakeCity:
         @staticmethod
         def main(
             cfg: dict[str, Any], save_path: str | None, duration: float
@@ -45,12 +56,10 @@ def test_dispatch_sets_simulator_fast_record(
             captured["save_path"] = save_path
             captured["duration"] = duration
 
-    monkeypatch.setattr(
-        arcosim_main.simulator,
-        "city",
-        _FakeModule(),
-        raising=False,
-    )
+    fake_main = types.ModuleType("arco.simulator.main")
+    fake_main.city = _FakeCity()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "arco.simulator.main", fake_main)
+
     cfg: dict[str, Any] = {"scenario": "city", "planner": {}}
     arcosim_main._dispatch(cfg, "/tmp/out.mp4", 45.0, fast_record=True)
     assert cfg["simulator"]["fast_record"] is True

--- a/tests/simulator/test_arcosim_cli.py
+++ b/tests/simulator/test_arcosim_cli.py
@@ -1,0 +1,58 @@
+"""Tests for the arcosim CLI fast-record / dispatch wiring."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+from arco.simulator import __main__ as arcosim_main
+
+
+def test_parse_args_fast_record_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "arcosim",
+            "map/city.yml",
+            "-o",
+            "/tmp/x.mp4",
+            "-d",
+            "30",
+            "--fast-record",
+        ],
+    )
+    args = arcosim_main.parse_args()
+    assert args.scenario_file == "map/city.yml"
+    assert args.output == "/tmp/x.mp4"
+    assert abs(args.record_duration - 30.0) < 1e-12
+    assert args.fast_record is True
+
+
+def test_dispatch_sets_simulator_fast_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeModule:
+        @staticmethod
+        def main(
+            cfg: dict[str, Any], save_path: str | None, duration: float
+        ) -> None:
+            captured["cfg"] = cfg
+            captured["save_path"] = save_path
+            captured["duration"] = duration
+
+    monkeypatch.setattr(
+        arcosim_main.simulator,
+        "city",
+        _FakeModule(),
+        raising=False,
+    )
+    cfg: dict[str, Any] = {"scenario": "city", "planner": {}}
+    arcosim_main._dispatch(cfg, "/tmp/out.mp4", 45.0, fast_record=True)
+    assert cfg["simulator"]["fast_record"] is True
+    assert captured["save_path"] == "/tmp/out.mp4"
+    assert abs(captured["duration"] - 45.0) < 1e-12


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal / objectives

Reduce **Release Videos** wall-clock, especially jobs that took **> 5 min**. Evidence from recent releases: wall-clock ≈ `Generate city video` (574 s → 1976 s); other scenarios were already under ~4.5 min.

## Acceptance criteria

- [x] Release city uses reduced planner budgets (`city_mpc_preview.yml`) but still publishes `arcosim_city.mp4`
- [x] Headless `--fast-record` skips animated tree reveal (city/vehicle/`run_sim`)
- [x] Release workflow: pip cache + conditional `arco[mpc]` install
- [x] Release clip duration 30 s with fast-record (≈ former race portion of 60 s clips)
- [x] Unit / script tests for CLI flag and `--release` dry-run remapping
- [x] Docs updated (`VISUALIZATION.md`, `STACK.md`)

## Changes

### 1. Preview map for release city
- `scripts/generate_videos.sh --release` → `map/city_mpc_preview.yml` for logical `city`, output still `arcosim_city.mp4`
- Primary scenario list avoids accidental double-runs of `*_preview.yml`

### 2. Fast-record (skip reveal)
- `arcosim --fast-record` sets `simulator.fast_record`
- `run_race` / `run_sim` jump past background reveal when recording
- Release uses `-d 30` so MPC-heavy race frames do not exceed the old race budget

### 3. CI install hygiene
- `actions/setup-python` pip cache on `pyproject.toml`
- Install `.[tools,pygame,mpc]` only for `city|vehicle|ppp|rrp`; others omit CasADi

## Expected impact

| Lever | Effect |
|-------|--------|
| Preview budgets (SST 80k → 4k, etc.) | Cuts city **planning** (main historical spike) |
| Fast-record + 30 s | Same race content as old 60 s (half reveal), less waste |
| Pip cache / conditional mpc | ~tens of seconds setup per job |

Wall-clock remains ≈ max(matrix) ≈ city race MPC cost; planning should no longer dominate.

## Test plan

- `pytest tests/simulator/test_arcosim_cli.py tests/scripts/test_generate_videos_release.py`
- `bash scripts/generate_videos.sh --release --only city --dry-run`
- `bash scripts/check_formatting.sh` / `bash scripts/run_tests.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-535a9a43-65f7-4606-97e5-48b8d0ef55e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-535a9a43-65f7-4606-97e5-48b8d0ef55e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

