### PR TITLE
fix(control): city A* (purple) stuck — floor polyline κ for MPC

### DIFF
--- a/docs/control_mpcc.md
+++ b/docs/control_mpcc.md
@@ -56,14 +56,19 @@ At each interior vertex, the turn between consecutive outgoing headings is
 
 \[
 \Delta\psi_i = \mathrm{wrap}\bigl(\psi_i - \psi_{i-1}\bigr),\qquad
-\kappa_i = \frac{\Delta\psi_i}{\min(\Delta s_{\mathrm{in}},\,\Delta s_{\mathrm{out}},\, s_{\mathrm{cap}})},
+\Delta s_i = \min(\Delta s_{\mathrm{in}},\,\Delta s_{\mathrm{out}},\, s_{\mathrm{cap}}),
 \]
 
-with \(s_{\mathrm{cap}} = 20\,\mathrm{m}\).  A backward max-preview
-(\(40\,\mathrm{m}\)) then exposes upcoming corner \(\kappa\) on the approach
-so the NMPC can brake before the kink.  (A skip-one finite difference
+and for non-trivial turns \(\Delta s_i \leftarrow \max(\Delta s_i,\, s_{\mathrm{floor}})\)
+with \(s_{\mathrm{cap}} = 20\,\mathrm{m}\) and \(s_{\mathrm{floor}} = 8\,\mathrm{m}\),
+then \(\kappa_i = \Delta\psi_i / \Delta s_i\).  A backward max-preview
+(\(40\,\mathrm{m}\)) exposes upcoming corner \(\kappa\) on the approach, and
+\(|\kappa|\) is clipped to \(\kappa_{\max} = 0.35\,\mathrm{m}^{-1}\) so
+short A*/optimizer stubs cannot create Dirac \(\kappa\) that makes
+long-horizon IPOPT solves fail (city purple racer stuck at
+\(v_{\mathrm{cmd}}=0\)).  A skip-one finite difference
 \(\psi_{i+1}-\psi_{i-1}\) can report \(\kappa \approx 0\) on a \(90^\circ\)
-L-corner and disable braking.)
+L-corner and disable braking — that is why consecutive headings are used.
 
 ---
 

--- a/src/arco/control/mpc/reference_path.py
+++ b/src/arco/control/mpc/reference_path.py
@@ -71,6 +71,14 @@ class ReferencePath:
     # forming κ for speed limiting.  Long collinear segments must not dilute
     # a 90° kink into κ≈0 (else ``v_curve = ω/|κ|`` never brakes).
     _CURVATURE_DS_CAP_M: float = 20.0
+    # Minimum spreading length (m) for a non-trivial turn.  Optimizer stubs
+    # and A* grid corners can be ~1 m; ``Δψ/ds`` then yields Dirac-like κ
+    # (|κ|≳1) that makes long-horizon ``v_curve`` NLPs fail (city purple
+    # racer stuck at speed 0 after ``solve_failed``).  Floor near half a
+    # city road half-width keeps braking meaningful without killing IPOPT.
+    _CURVATURE_DS_FLOOR_M: float = 8.0
+    # Hard cap on |κ| (1/m) after preview — safety net for the NLP.
+    _CURVATURE_ABS_MAX: float = 0.35
     # Backward horizon (m) over which an upcoming corner κ is visible so the
     # NMPC can decelerate before the kink (≈ cruise² / (2 a) at city soft
     # limits).
@@ -85,16 +93,18 @@ class ReferencePath:
         """Estimate curvature from consecutive segment heading changes.
 
         Each interior vertex uses the turn between its incoming and outgoing
-        headings, spread over ``min(ds_in, ds_out, ds_cap)``.  A skip-one
-        finite difference (``h[i+1] - h[i-1]``) can report ``κ ≈ 0`` on a
-        90° L-kink when those headings cancel, which disabled curve-speed
-        limiting on city A*/RRT* polylines.  A backward max-preview then
-        keeps the corner ``κ`` visible on the approach so braking starts
-        before the vertex.
+        headings, spread over ``min(ds_in, ds_out, ds_cap)`` and, for
+        non-trivial turns, at least ``ds_floor`` so short polyline stubs do
+        not create Dirac κ.  A skip-one finite difference
+        (``h[i+1] - h[i-1]``) can report ``κ ≈ 0`` on a 90° L-kink when
+        those headings cancel, which disabled curve-speed limiting on city
+        A*/RRT* polylines.  A backward max-preview then keeps the corner
+        ``κ`` visible on the approach so braking starts before the vertex.
         """
         kappa = np.zeros_like(headings)
         n = len(headings)
         ds_cap = float(cls._CURVATURE_DS_CAP_M)
+        ds_floor = float(cls._CURVATURE_DS_FLOOR_M)
         for i in range(1, n - 1):
             ds_in = float(cumulative[i] - cumulative[i - 1])
             ds_out = float(cumulative[i + 1] - cumulative[i])
@@ -105,6 +115,8 @@ class ReferencePath:
                 math.sin(headings[i] - headings[i - 1]),
                 math.cos(headings[i] - headings[i - 1]),
             )
+            if abs(dtheta) > 1e-6:
+                ds = max(ds, ds_floor)
             kappa[i] = dtheta / ds
         if n >= 2:
             kappa[0] = kappa[1]
@@ -112,20 +124,25 @@ class ReferencePath:
 
         preview = float(cls._CURVATURE_PREVIEW_DS_M)
         if preview <= 0.0 or n < 2:
-            return kappa
-        previewed = kappa.copy()
-        for i in range(n):
-            s_i = float(cumulative[i])
-            best = float(previewed[i])
-            best_abs = abs(best)
-            for j in range(i + 1, n):
-                if float(cumulative[j]) - s_i > preview:
-                    break
-                cand = float(kappa[j])
-                if abs(cand) > best_abs:
-                    best = cand
-                    best_abs = abs(cand)
-            previewed[i] = best
+            previewed = kappa
+        else:
+            previewed = kappa.copy()
+            for i in range(n):
+                s_i = float(cumulative[i])
+                best = float(previewed[i])
+                best_abs = abs(best)
+                for j in range(i + 1, n):
+                    if float(cumulative[j]) - s_i > preview:
+                        break
+                    cand = float(kappa[j])
+                    if abs(cand) > best_abs:
+                        best = cand
+                        best_abs = abs(cand)
+                previewed[i] = best
+
+        k_max = float(cls._CURVATURE_ABS_MAX)
+        if k_max > 0.0:
+            previewed = np.clip(previewed, -k_max, k_max)
         return previewed
 
     @property

--- a/tests/control/mpc/test_path_following_mpc.py
+++ b/tests/control/mpc/test_path_following_mpc.py
@@ -443,3 +443,77 @@ def test_mpc_lane_aware_corner_stays_inside_road_budget() -> None:
     assert max_abs_lat < road_half_width - 4.0
     # May use the free band, but must not treat half the road as free.
     assert max_abs_lat < 2.0 * deadzone + 3.0
+
+
+def test_mpc_city_horizon_solves_dense_astar_style_kinks() -> None:
+    """Same tracker as RRT*/SST must move on a dense A*-like polyline.
+
+    v0.3.5 city release: purple (A*) path existed but IPOPT ``solve_failed``
+    on every step (Dirac κ from ~1 m stubs + horizon 72) → permanent
+    ``speed_cmd=0``.  RRT*/SST used the identical MPC factory and moved.
+    """
+    # Stair-step corridor with short stubs at each 90° corner (optimizer-like).
+    path: list[tuple[float, float]] = [(0.0, 0.0)]
+    x = 0.0
+    y = 0.0
+    for i in range(6):
+        x += 12.0
+        path.append((x, y))
+        path.append((x + 1.2, y))  # short stub
+        y += 12.0
+        path.append((x + 1.2, y))
+        x += 1.2
+    path.append((x + 20.0, y))
+
+    cfg = _cfg(
+        cruise_speed=12.0,
+        weight_contour=8.0,
+        weight_heading=4.0,
+        weight_progress=4.0,
+        weight_lag=4.0,
+        contour_deadzone=2.5,
+        weight_control=0.5,
+        weight_obstacle=0.0,
+        weight_terminal=8.0,
+        horizon_step_count=72,
+        dt=0.05,
+        max_solver_iter_count=80,
+    )
+    limits = _limits(
+        max_speed=16.0,
+        min_speed=0.0,
+        max_turn_rate=math.radians(40.0),
+        max_acceleration=2.5,
+        max_turn_rate_dot=math.radians(90.0),
+    )
+    mpc = DubinsPathFollowingMPC(vehicle_limits=limits, config=cfg)
+    mpc.set_reference(path)
+    vehicle = DubinsVehicle(
+        x=path[0][0],
+        y=path[0][1],
+        heading=0.0,
+        max_speed=limits.max_speed,
+        min_speed=limits.min_speed,
+        max_turn_rate=limits.max_turn_rate,
+        max_acceleration=limits.max_acceleration,
+        max_turn_rate_dot=limits.max_turn_rate_dot,
+    )
+    # Match race start: vehicle begins at rest.
+    vehicle._speed = 0.0
+
+    dt = 0.1
+    success_count = 0
+    for _ in range(25):
+        result = mpc.step(
+            vehicle.pose,
+            speed=vehicle.speed,
+            turn_rate=vehicle.turn_rate,
+            dt=dt,
+        )
+        if result.solver_success:
+            success_count += 1
+        vehicle.step(result.speed_cmd, result.turn_rate_cmd, dt)
+
+    assert success_count >= 20
+    assert vehicle.speed > 1.0
+    assert math.hypot(vehicle.x - path[0][0], vehicle.y - path[0][1]) > 2.0

--- a/tests/control/mpc/test_reference_path.py
+++ b/tests/control/mpc/test_reference_path.py
@@ -94,6 +94,28 @@ def test_reference_path_curvature_grid_corner_limits_city_speed() -> None:
     assert v_curve < 12.0
 
 
+def test_reference_path_curvature_floors_short_stub_turns() -> None:
+    """Sub-meter corner stubs must not create Dirac κ for the NMPC.
+
+    City A* / optimizer polylines often keep ~1 m segments at 90° kinks.
+    Without a ds floor, |κ|≳1 and long-horizon ``v_curve`` solves fail,
+    leaving the purple racer at ``speed_cmd=0`` after ``solve_failed``.
+    """
+    path = ReferencePath(
+        [
+            (0.0, 0.0),
+            (10.0, 0.0),
+            (11.2, 0.0),  # short stub into the corner
+            (11.2, 1.2),
+            (11.2, 20.0),
+        ]
+    )
+    kappa = abs(path.curvature(11.2))
+    assert kappa <= ReferencePath._CURVATURE_ABS_MAX + 1e-9
+    # Still large enough to pull cruise down (not the old κ≈0 bug).
+    assert kappa > 0.05
+
+
 def test_reference_path_total_length() -> None:
     path = ReferencePath([(0.0, 0.0), (3.0, 4.0)])
     assert abs(path.total_length - 5.0) < 1e-9


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal / objectives

In **v0.3.5** city release video, the purple (A*) car never moves while blue (RRT*) and green (SST) race normally. All three vehicles must share the **same** tracking pipeline; only the planner-provided path input differs.

## Root cause

You were right about the architecture: `build_vehicle_mpc_sim` is identical for all three. The A* path *was* produced and drawn.

What differed was **path geometry → κ for `v_curve`**:

1. A*/optimizer polylines keep **~1 m stubs** at 90° kinks.
2. Consecutive-heading κ used `Δψ / min(ds_in, ds_out)` → **Dirac-like |κ| ≳ 1**.
3. City horizon (72) + that κ made **every IPOPT solve fail** (`solve_failed`).
4. On failure the tracker safe-stops with **`speed_cmd = 0`** → purple never leaves the start.
5. RRT*/SST paths are smoother (`|κ|_max ≈ 0.1`), so the **same** MPC succeeds.

Repro (preview map): A* `success=0/30`, displacement 0; after fix `30/30`, same ~5.8 m / 3.75 m/s as the others.

## Fix

In `ReferencePath` curvature for speed limiting:

- Floor turn spreading length at **8 m** for non-trivial turns
- Clip **|κ| ≤ 0.35 m⁻¹** after preview

Braking on real corners remains; dense A* stubs no longer kill the NLP.

## Acceptance criteria

- [x] Dense A*-style polyline + city horizon: solver succeeds and vehicle moves from rest
- [x] City preview A*/RRT*/SST all displace similarly in a 30-step smoke
- [x] Existing L-kink / lane-aware tests still pass
- [x] Docs (`control_mpcc.md`) updated

## Test plan

- `pytest tests/control/mpc/test_reference_path.py tests/control/mpc/test_path_following_mpc.py`
- Local: build `CityScene` from `map/city_mpc_preview.yml` and step all three trackers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-535a9a43-65f7-4606-97e5-48b8d0ef55e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-535a9a43-65f7-4606-97e5-48b8d0ef55e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

