### PR TITLE
fix(control): stiffen city MPC against zigzags and wall cuts

### DIFF
--- a/docs/GUIDANCE.md
+++ b/docs/GUIDANCE.md
@@ -45,20 +45,21 @@ Feedback controllers that generate control inputs to track a reference trajector
   - Paired with `MPCTrackingLoop`
   - Enable in SE(2) races with `simulator.tracker: mpc`
   - City race may override `simulator.mpc.horizon` (default **3.6 s**,
-    ~half a city block) and uses **lane-aware progress-first contouring**:
-    a *small* lateral deadzone (≪ road half-width) plus a moderate lag
-    penalty so the NMPC may widen sharp A* kinks **inside the navigable
-    lane** while `s` advances.  Planners ignore vehicle dynamics; the
-    tracker treats the plan as a topological lane guide, not a free
-    band into the buildings.  Polyline curvature uses consecutive
-    heading turns + approach preview so `v_curve = ω/|κ|` brakes before
-    90° kinks (a skip-one κ estimate used to report κ≈0 on L-corners).
+    ~half a city block) and uses **stiffened lane-aware contouring**:
+    a *small* lateral deadzone (≪ road half-width), high control /
+    contour / obstacle weights, and a capped ω̇ so the NMPC may open a
+    sharp A* kink **once** inside the lane without zigzag hunting or
+    cutting buildings.  Planners ignore vehicle dynamics; the tracker
+    treats the plan as a topological lane guide.  Obstacle sampling
+    includes forward / lateral probes around the vehicle, not only the
+    path centerline.  Polyline curvature uses consecutive heading turns
+    + approach preview so `v_curve = ω/|κ|` brakes before 90° kinks.
   - Contouring progress uses `ṡ = v max(cos e_ψ, 0)` so recovery arcs do
     not reverse the path parameter (the limit-cycle behind city A* loops)
   - Trajectory evolution: on straights the car stays near the reference;
-    on planner kinks it slows to a lane-feasible radius, widens within
-    the deadzone, and keeps `s` increasing — instead of snap-turning,
-    orbiting, or cutting into walls
+    on planner kinks it slows to a lane-feasible radius, widens a little,
+    and keeps `s` increasing — instead of snap-turning, weaving, or
+    cutting into walls
 
 - **JointSpaceMPC** (`arco.control.mpc.joint_space`): N-DOF carrot-tracking NMPC
   - Drop-in for `JointSpaceTracker` (`reset` / `step` API)

--- a/docs/VISUALIZATION.md
+++ b/docs/VISUALIZATION.md
@@ -80,13 +80,13 @@ City race notes when `simulator.tracker: mpc`:
 
 - Scenario YAML may set `simulator.mpc.horizon.{step_count,dt}` (city default
   is **72 × 0.05 s = 3.6 s**, ~43 m at the soft 12 m/s cruise ≈ half a block).
-  City uses **lane-aware progress-first** (`contour_deadzone: 2.5 m`,
-  `lag: 4`, stronger contour outside the band) plus soft but lane-viable
-  turn limits: planners ignore dynamics, so the tracker widens infeasible
-  kinks **inside the road corridor** while `s` advances (see
+  City uses **stiffened lane-aware contouring** (`contour_deadzone: 1.2 m`,
+  `control: 4`, `contour: 18`, `obstacle: 280`, mild `lag: 2`) plus a
+  softer ω̇ limit (55 °/s²): planners ignore dynamics, so the tracker may
+  open a sharp kink **a little** inside the road corridor, but high
+  control / contour / obstacle weights kill zigzags and wall cuts (see
   `tools/mpc_progress_first_demo.py`).  A prior 8 m deadzone ate the
-  planner clearance and drove cars into walls; v0.3.3 orbits came from
-  reversing contouring progress.
+  planner clearance; low `control` let A* polylines hunt left/right.
 - The race renderer draws each racer's **MPC predicted XY polyline** (no tip
   disc) instead of a Pure-Pursuit carrot.
 - Race glyphs stay **oriented rectangles** (`8.0 × 3.6` m half-extents) with

--- a/docs/control_mpcc.md
+++ b/docs/control_mpcc.md
@@ -226,8 +226,9 @@ Weights map to `PathFollowingMPCConfig` / YAML `simulator.mpc.weights`:
 | \(d_{\mathrm{dz}}\) | `contour_deadzone` |
 
 Default global `mpc.yml` is **stiff** (\(d_{\mathrm{dz}}=0\), \(w_{\mathrm{lag}}=0\)).
-City overrides are **lane-aware progress-first** (small deadzone, moderate lag,
-stronger contour outside the band).
+City overrides are **stiffened lane-aware** (small deadzone ≈ 1.2 m, high
+\(w_u\) / \(w_c\) / \(w_{\mathrm{obs}}\), mild lag) so corners may open a
+little without zigzag hunting or wall cuts.
 
 ### Soft obstacle barriers
 
@@ -314,16 +315,18 @@ from arco.control.mpc import (
 limits = DubinsVehicleLimits(
     max_speed=16.0,
     min_speed=0.0,
-    max_turn_rate=0.70,       # rad/s
+    max_turn_rate=0.70,       # rad/s (~40 deg/s)
     max_acceleration=2.5,
-    max_turn_rate_dot=1.57,
+    max_turn_rate_dot=0.96,   # rad/s² (~55 deg/s²)
 )
 cfg = PathFollowingMPCConfig.create_from_config().with_weight_overrides(
-    contour=8.0,
-    heading=4.0,
-    progress=4.0,
-    lag=4.0,
-    contour_deadzone=2.5,
+    contour=18.0,
+    heading=6.0,
+    control=4.0,
+    progress=3.0,
+    lag=2.0,
+    obstacle=280.0,
+    contour_deadzone=1.2,
 )
 mpc = DubinsPathFollowingMPC(vehicle_limits=limits, config=cfg)
 mpc.set_reference([(0.0, 0.0), (40.0, 0.0), (40.0, 40.0)])

--- a/map/city.yml
+++ b/map/city.yml
@@ -53,21 +53,19 @@ world:
 # follows that arbitrary reference (no replanning inside the tracker).
 simulator:
   tracker: mpc  # "pure_pursuit" (PP+APF) or "mpc" (CasADi path-following NMPC)
-  # Lane-aware progress-first contouring.  Global planners ignore vehicle
-  # dynamics, so the tracker may widen sharp polyline kinks — but only inside
-  # a small free band (≪ road half-width / clearance).  A large deadzone ate
-  # the planner's obstacle clearance and drove cars into walls.  Lag still
-  # prefers advancing s over nailing the kink; contour outside the band keeps
-  # the topological lane.  Global mpc.yml remains stiff (deadzone=0, lag=0).
+  # Lane-aware progress-first contouring (stiffened).  Planners ignore
+  # dynamics: allow a *small* free band to open sharp kinks, but keep high
+  # control / contour / obstacle weights so the car does not zigzag or cut
+  # through buildings.  Global mpc.yml remains classic stiff (deadzone=0).
   mpc:
     horizon:
       step_count: 72  # [] prediction steps
       dt: 0.05  # [s] prediction model step
     weights:
-      contour: 8.0  # [] excess-lateral weight outside the deadzone
-      heading: 4.0  # [] heading tracking (plan has no yaw continuity)
-      control: 0.5  # [] control effort — prefer smooth ω
-      progress: 4.0  # [] track v_ref (incl. curve-limited corner speed)
-      lag: 4.0  # [] behind-schedule progress (do not overpower braking)
-      obstacle: 120.0  # [] keep the topological lane clear of buildings
-      contour_deadzone: 2.5  # [m] free |e_lat| band (widen inside the lane)
+      contour: 18.0  # [] excess-lateral weight outside the deadzone
+      heading: 6.0  # [] heading tracking (soft vs polyline yaw jumps)
+      control: 4.0  # [] penalize a / ω̇ — kill zigzag hunting
+      progress: 3.0  # [] track v_ref (incl. curve-limited corner speed)
+      lag: 2.0  # [] mild progress preference (do not force wall cuts)
+      obstacle: 280.0  # [] keep the topological lane clear of buildings
+      contour_deadzone: 1.2  # [m] free |e_lat| band (widen a little, not weave)

--- a/map/city_mpc_preview.yml
+++ b/map/city_mpc_preview.yml
@@ -28,16 +28,16 @@ world:
   seed: 42
 simulator:
   tracker: mpc
-  # Match city.yml: half-block horizon + lane-aware progress-first.
+  # Match city.yml: half-block horizon + stiffened lane-aware contouring.
   mpc:
     horizon:
       step_count: 72
       dt: 0.05
     weights:
-      contour: 8.0
-      heading: 4.0
-      control: 0.5
-      progress: 4.0
-      lag: 4.0
-      obstacle: 120.0
-      contour_deadzone: 2.5
+      contour: 18.0
+      heading: 6.0
+      control: 4.0
+      progress: 3.0
+      lag: 2.0
+      obstacle: 280.0
+      contour_deadzone: 1.2

--- a/src/arco/control/mpc/path_following.py
+++ b/src/arco/control/mpc/path_following.py
@@ -274,7 +274,10 @@ class DubinsPathFollowingMPC(MPCTracker):
     racing MPCC are documented in ``docs/control_mpcc.md``.
     """
 
-    _OBSTACLE_SAMPLE_COUNT = 5
+    # Nearest-obstacle parameter slots fed to the NLP.  Pose + path preview
+    # + lateral / forward probes around the vehicle (city A* cuts need denser
+    # barriers than a pure centerline sample).
+    _OBSTACLE_SAMPLE_COUNT = 9
     _PATH_INTERP_COUNT = 200
 
     def __init__(
@@ -586,17 +589,34 @@ class DubinsPathFollowingMPC(MPCTracker):
             self._occupancy, "nearest_obstacle"
         ):
             return []
-        samples: list[tuple[float, float]] = []
-        pts = [np.array([pose[0], pose[1]], dtype=float)]
+        px, py, theta = pose
+        cth = float(np.cos(theta))
+        sth = float(np.sin(theta))
+        # Query centers: vehicle, forward cone, left/right flanks (catches
+        # corner cuts that leave the path centerline), then path preview.
+        pts: list[np.ndarray] = [np.array([px, py], dtype=float)]
+        for fwd in (8.0, 18.0):
+            pts.append(
+                np.array([px + fwd * cth, py + fwd * sth], dtype=float)
+            )
+        for lat in (-8.0, 8.0):
+            pts.append(
+                np.array(
+                    [px - lat * sth, py + lat * cth],
+                    dtype=float,
+                )
+            )
         if self._reference is not None:
             look_ahead = self._look_ahead_distance()
-            for alpha in np.linspace(0.0, 1.0, self._OBSTACLE_SAMPLE_COUNT):
+            path_samples = max(3, self._OBSTACLE_SAMPLE_COUNT - 4)
+            for alpha in np.linspace(0.0, 1.0, path_samples):
                 s = min(
                     self._progress + alpha * look_ahead,
                     self._reference.total_length,
                 )
                 x_ref, y_ref = self._reference.position(s)
                 pts.append(np.array([x_ref, y_ref], dtype=float))
+        samples: list[tuple[float, float]] = []
         seen: set[tuple[float, float]] = set()
         for pt in pts:
             _dist, nearest = self._occupancy.nearest_obstacle(pt)
@@ -605,6 +625,8 @@ class DubinsPathFollowingMPC(MPCTracker):
                 continue
             seen.add(key)
             samples.append((float(nearest[0]), float(nearest[1])))
+            if len(samples) >= self._OBSTACLE_SAMPLE_COUNT:
+                break
         return samples
 
     def _build_nlp(self, obstacle_count: int) -> dict[str, Any]:

--- a/src/arco/control/mpc/path_following.py
+++ b/src/arco/control/mpc/path_following.py
@@ -596,9 +596,7 @@ class DubinsPathFollowingMPC(MPCTracker):
         # corner cuts that leave the path centerline), then path preview.
         pts: list[np.ndarray] = [np.array([px, py], dtype=float)]
         for fwd in (8.0, 18.0):
-            pts.append(
-                np.array([px + fwd * cth, py + fwd * sth], dtype=float)
-            )
+            pts.append(np.array([px + fwd * cth, py + fwd * sth], dtype=float))
         for lat in (-8.0, 8.0):
             pts.append(
                 np.array(

--- a/src/arco/simulator/sim/city_race_style.py
+++ b/src/arco/simulator/sim/city_race_style.py
@@ -45,7 +45,9 @@ CITY_MAX_SPEED: float = 16.0
 CITY_CRUISE_SPEED: float = 12.0
 CITY_MAX_TURN_RATE_DEG: float = 40.0
 CITY_MAX_ACCELERATION: float = 2.5
-CITY_MAX_TURN_RATE_DOT_DEG: float = 90.0
+# Lower ω̇ max damps left/right hunting on jagged A* polylines while still
+# allowing a single smooth widen of a corner inside the lane.
+CITY_MAX_TURN_RATE_DOT_DEG: float = 55.0
 CITY_LOOKAHEAD_DISTANCE: float = 28.0
 CITY_GOAL_RADIUS: float = 20.0
 # City road half-width (m); used by tests / docs as the lane budget.

--- a/tests/control/mpc/test_path_following_mpc.py
+++ b/tests/control/mpc/test_path_following_mpc.py
@@ -526,7 +526,7 @@ def test_obstacle_samples_include_lateral_probes() -> None:
     centerline nearest-obstacle query when the car is still on-path; lateral
     probes must surface it in the NLP barrier set.
     """
-    from arco.mapping.occupancy import KDTreeOccupancy
+    from arco.mapping import KDTreeOccupancy
 
     # Sparse flank cloud: only points on the left of a +x path.
     cloud = [[0.0, 8.0], [8.0, 8.0], [16.0, 8.0], [24.0, 8.0]]

--- a/tests/control/mpc/test_path_following_mpc.py
+++ b/tests/control/mpc/test_path_following_mpc.py
@@ -517,3 +517,29 @@ def test_mpc_city_horizon_solves_dense_astar_style_kinks() -> None:
     assert success_count >= 20
     assert vehicle.speed > 1.0
     assert math.hypot(vehicle.x - path[0][0], vehicle.y - path[0][1]) > 2.0
+
+
+def test_obstacle_samples_include_lateral_probes() -> None:
+    """City cuts need flank queries, not only path-centerline samples.
+
+    A wall parallel to the path (offset ~8 m left) is invisible to a pure
+    centerline nearest-obstacle query when the car is still on-path; lateral
+    probes must surface it in the NLP barrier set.
+    """
+    from arco.mapping.occupancy import KDTreeOccupancy
+
+    # Sparse flank cloud: only points on the left of a +x path.
+    cloud = [[0.0, 8.0], [8.0, 8.0], [16.0, 8.0], [24.0, 8.0]]
+    occ = KDTreeOccupancy(cloud, clearance=2.0)
+    cfg = _cfg(weight_obstacle=280.0)
+    mpc = DubinsPathFollowingMPC(
+        vehicle_limits=_limits(),
+        config=cfg,
+        occupancy=occ,
+    )
+    mpc.set_reference([(float(i), 0.0) for i in range(0, 41)])
+    assert DubinsPathFollowingMPC._OBSTACLE_SAMPLE_COUNT >= 9
+    samples = mpc._collect_obstacle_samples((0.0, 0.0, 0.0))
+    assert samples
+    assert any(abs(y - 8.0) < 1e-9 for _x, y in samples)
+    assert len(samples) <= DubinsPathFollowingMPC._OBSTACLE_SAMPLE_COUNT

--- a/tests/control/mpc/test_tracking_loop.py
+++ b/tests/control/mpc/test_tracking_loop.py
@@ -105,21 +105,22 @@ def test_build_vehicle_mpc_sim_preserves_progress_first_weights() -> None:
         goal_radius=20.0,
         max_turn_rate=math.radians(40.0),
         max_acceleration=2.5,
-        max_turn_rate_dot=math.radians(90.0),
+        max_turn_rate_dot=math.radians(55.0),
     )
     mpc_cfg = PathFollowingMPCConfig.create_from_config().with_weight_overrides(
-        contour=8.0,
-        heading=4.0,
-        progress=4.0,
-        lag=4.0,
-        control=0.5,
-        obstacle=120.0,
-        contour_deadzone=2.5,
+        contour=18.0,
+        heading=6.0,
+        progress=3.0,
+        lag=2.0,
+        control=4.0,
+        obstacle=280.0,
+        contour_deadzone=1.2,
     )
     _vehicle, loop = build_vehicle_mpc_sim(path, cfg, mpc_cfg)
     live = loop.tracker.config
     assert abs(live.cruise_speed - 12.0) < 1e-12
-    assert abs(live.weight_lag - 4.0) < 1e-12
-    assert abs(live.contour_deadzone - 2.5) < 1e-12
-    assert abs(live.weight_contour - 8.0) < 1e-12
-    assert abs(live.weight_obstacle - 120.0) < 1e-12
+    assert abs(live.weight_lag - 2.0) < 1e-12
+    assert abs(live.contour_deadzone - 1.2) < 1e-12
+    assert abs(live.weight_contour - 18.0) < 1e-12
+    assert abs(live.weight_control - 4.0) < 1e-12
+    assert abs(live.weight_obstacle - 280.0) < 1e-12

--- a/tests/simulator/sim/test_city_race_style.py
+++ b/tests/simulator/sim/test_city_race_style.py
@@ -77,12 +77,12 @@ def test_city_vehicle_dynamics_are_soft_but_lane_viable() -> None:
     assert CITY_MAX_SPEED == 16.0
     assert CITY_MAX_TURN_RATE_DEG == 40.0
     assert CITY_MAX_ACCELERATION == 2.5
-    assert CITY_MAX_TURN_RATE_DOT_DEG == 90.0
+    assert CITY_MAX_TURN_RATE_DOT_DEG == 55.0
     assert CITY_ROAD_HALF_WIDTH == 15.0
     cfg = make_city_vehicle_config()
     assert abs(cfg.cruise_speed - CITY_CRUISE_SPEED) < 1e-12
     assert abs(cfg.max_turn_rate - math.radians(40.0)) < 1e-12
-    assert abs(cfg.max_turn_rate_dot - math.radians(90.0)) < 1e-12
+    assert abs(cfg.max_turn_rate_dot - math.radians(55.0)) < 1e-12
     assert abs(cfg.max_acceleration - 2.5) < 1e-12
     # Soft: still cannot snap-turn a kink at full cruise.
     assert cfg.cruise_speed / cfg.max_turn_rate > CITY_ROAD_HALF_WIDTH
@@ -124,28 +124,28 @@ def test_path_following_mpc_config_honors_weight_overrides() -> None:
             "mpc": {
                 "horizon": {"step_count": 72, "dt": 0.05},
                 "weights": {
-                    "contour": 8.0,
-                    "heading": 4.0,
-                    "control": 0.5,
-                    "progress": 4.0,
-                    "lag": 4.0,
-                    "contour_deadzone": 2.5,
+                    "contour": 18.0,
+                    "heading": 6.0,
+                    "control": 4.0,
+                    "progress": 3.0,
+                    "lag": 2.0,
+                    "contour_deadzone": 1.2,
                 },
             },
         },
         default_horizon_step_count=72,
         default_horizon_dt=0.05,
     )
-    assert abs(cfg.weight_contour - 8.0) < 1e-12
-    assert abs(cfg.weight_heading - 4.0) < 1e-12
-    assert abs(cfg.weight_control - 0.5) < 1e-12
-    assert abs(cfg.weight_progress - 4.0) < 1e-12
-    assert abs(cfg.weight_lag - 4.0) < 1e-12
-    assert abs(cfg.contour_deadzone - 2.5) < 1e-12
+    assert abs(cfg.weight_contour - 18.0) < 1e-12
+    assert abs(cfg.weight_heading - 6.0) < 1e-12
+    assert abs(cfg.weight_control - 4.0) < 1e-12
+    assert abs(cfg.weight_progress - 3.0) < 1e-12
+    assert abs(cfg.weight_lag - 2.0) < 1e-12
+    assert abs(cfg.contour_deadzone - 1.2) < 1e-12
 
 
-def test_city_map_yaml_declares_lane_aware_progress_first() -> None:
-    """City YAML widens kinks inside the lane, not into walls."""
+def test_city_map_yaml_declares_stiff_lane_aware_contouring() -> None:
+    """City YAML allows a little widen, but not zigzags or wall cuts."""
     root = Path(__file__).resolve().parents[3]
     for name in ("city.yml", "city_mpc_preview.yml"):
         data = yaml.safe_load((root / "map" / name).read_text())
@@ -156,12 +156,12 @@ def test_city_map_yaml_declares_lane_aware_progress_first() -> None:
             < 1e-12
         )
         weights = data["simulator"]["mpc"]["weights"]
-        # Contour outside the band must dominate wall-seeking freedom.
-        assert float(weights["contour"]) >= 6.0
-        assert float(weights["heading"]) >= 3.0
-        assert float(weights["lag"]) >= 2.0
-        assert float(weights["lag"]) <= 6.0
+        assert float(weights["contour"]) >= 12.0
+        assert float(weights["heading"]) >= 4.0
+        assert float(weights["control"]) >= 2.0
+        assert float(weights["lag"]) >= 1.0
+        assert float(weights["lag"]) <= 3.0
         # Free band ≪ road half-width (15 m) and planner clearance (8 m).
         deadzone = float(weights["contour_deadzone"])
-        assert 1.0 <= deadzone <= 4.0
-        assert float(weights["obstacle"]) >= 100.0
+        assert 0.5 <= deadzone <= 2.0
+        assert float(weights["obstacle"]) >= 200.0

--- a/tools/mpc_progress_first_demo.py
+++ b/tools/mpc_progress_first_demo.py
@@ -130,7 +130,7 @@ def main() -> Path:
         weight_control=0.5,
         weight_obstacle=0.0,
         weight_terminal=8.0,
-        contour_deadzone=1.2,  # scaled free band (~city 2.5 m)
+        contour_deadzone=1.2,  # matches city free band (widen a little)
         max_solver_iter_count=60,
     )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal / objectives

After the A* κ-floor fix, the purple (A*) racer could move again but:

1. **Cut through buildings** — soft obstacles + sparse centerline samples + a still-too-wide free band let the tracker leave the topological lane.
2. **Zigzag / hunt** — very low `weight_control` (0.5) plus a high ω̇ limit (90 °/s²) chased jagged A* headings left/right.

Acceptable criteria:

- City YAML / preview share stiffened lane-aware weights: high contour / control / obstacle, mild lag, deadzone ≪ road half-width (≈ 1.2 m).
- Turn-rate derivative capped at 55 °/s² so one smooth widen is possible, not weave.
- Obstacle NLP samples include forward + lateral probes around the vehicle (not only path centerline).
- Same shared MPC pipeline for all three racers; color still only identifies the planner.
- Unit tests + formatting + smoke tests pass; docs match the new city defaults.

## Changes

- `map/city.yml` / `map/city_mpc_preview.yml`: contour 18, heading 6, control 4, progress 3, lag 2, obstacle 280, deadzone 1.2 m.
- `CITY_MAX_TURN_RATE_DOT_DEG`: 90 → 55.
- `DubinsPathFollowingMPC`: `_OBSTACLE_SAMPLE_COUNT` 5 → 9 with pose / forward / flank / path preview queries.
- Tests + docs (`VISUALIZATION`, `GUIDANCE`, `control_mpcc`) updated.

## Verification

- `bash scripts/check_formatting.sh` — pass
- `bash scripts/run_tests.sh` — 782 passed, 2 xfailed
- Smoke: `city`, `vehicle`, `occ`, `astar`, `rr`, `ppp`, `rrp` — all pass
- Synthetic L-path + wall cloud: min clearance improved ~3.4 m → ~5.3 m with the stiff tune

![City MPC stiffening clearance compare](https://cursor.com/artifacts/c/art-2a9cc715-133e-4ca0-982e-34a724f2c57d)
![Turn-rate stiffness compare](https://cursor.com/artifacts/c/art-4f214d6a-0bde-42b0-b806-7333fc42e455)

## Notes

Still soft barriers (not a hard road tube). Opening a corner a little inside the lane remains intentional; hunting and cutting walls should not.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-535a9a43-65f7-4606-97e5-48b8d0ef55e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-535a9a43-65f7-4606-97e5-48b8d0ef55e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

