### PR TITLE
feat(simulator): shared presentation chrome + city deadzone=0

### DIFF
--- a/docs/GUIDANCE.md
+++ b/docs/GUIDANCE.md
@@ -46,19 +46,21 @@ Feedback controllers that generate control inputs to track a reference trajector
   - Paired with `MPCTrackingLoop`
   - Enable in SE(2) races with `simulator.tracker: mpc`
   - City race may override `simulator.mpc.horizon` (default **3.6 s**,
-    ~half a city block) and uses **lane-aware progress-first contouring**:
-    a *small* lateral deadzone (≪ road half-width) plus moderate lag so
-    the NMPC may widen sharp A* kinks **inside the navigable lane** while
-    `s` advances.  Planners ignore vehicle dynamics; the tracker treats
-    the plan as a topological lane guide, not a free band into buildings.
-    Polyline curvature uses consecutive heading turns + approach preview
-    so `v_curve = ω/|κ|` brakes before 90° kinks (κ floor keeps dense A*
+    ~half a city block) and uses **progress-first contouring** with
+    **`contour_deadzone = 0`**: moderate lag/progress trade against a
+    strictly quadratic lateral cost so the NMPC may widen sharp A* kinks
+    **inside the navigable lane** while `s` advances.  Flat deadzone bands
+    zero the lateral gradient and invite equal-cost left/right chatter.
+    Planners ignore vehicle dynamics; the tracker treats the plan as a
+    topological lane guide, not free space into buildings.  Polyline
+    curvature uses consecutive heading turns + approach preview so
+    `v_curve = ω/|κ|` brakes before 90° kinks (κ floor keeps dense A*
     stubs IPOPT-solvable).
   - Contouring progress uses `ṡ = v max(cos e_ψ, 0)` so recovery arcs do
     not reverse the path parameter (the limit-cycle behind city A* loops)
   - Trajectory evolution: on straights the car stays near the reference;
-    on planner kinks it slows to a lane-feasible radius, widens within
-    the deadzone, and keeps `s` increasing — instead of snap-turning,
+    on planner kinks it slows to a lane-feasible radius, trades contour
+    cost for progress, and keeps `s` increasing — instead of snap-turning,
     orbiting, or cutting into walls
 - **JointSpaceMPC** (`arco.control.mpc.joint_space`): N-DOF carrot-tracking NMPC
   - Drop-in for `JointSpaceTracker` (`reset` / `step` API)

--- a/docs/VISUALIZATION.md
+++ b/docs/VISUALIZATION.md
@@ -59,6 +59,19 @@ arcosim map/city.yml --static --record output/city.png
 | `rrp`    | RRP SCARA arm — joint-space MPC |
 | `occ`    | Piano-movers — multi-actuator object transport |
 
+### Shared presentation chrome
+
+All four scenarios compose the same shell via
+`arco.simulator.sim.layout.ScreenLayout`:
+
+- **Header** — left-aligned phase title (`City · race`, `PPP · path reveal`, …)
+  plus a thin **method accent stripe** (RRT* / SST / A* colors from the palette)
+- **Sidebar** — compact planner summary or race standings with method accent bars
+- **Footer** — controls / phase hint
+- **Content** — scenario viewport (city follow-cam, PPP/RRP 3-D, OCC dual panels)
+
+Chrome colors live under `ui.chrome_*` in `src/arco/config/colors.yml`.
+
 ### Release / CI video generation
 
 `scripts/generate_videos.sh --release` (used by `.github/workflows/release.yml`):

--- a/docs/VISUALIZATION.md
+++ b/docs/VISUALIZATION.md
@@ -77,18 +77,21 @@ City race notes when `simulator.tracker: mpc`:
 
 - Scenario YAML may set `simulator.mpc.horizon.{step_count,dt}` (city default
   is **72 × 0.05 s = 3.6 s**, ~43 m at the soft 12 m/s cruise ≈ half a block).
-  City uses **lane-aware progress-first** (`contour_deadzone: 2.5 m`,
-  `lag: 4`, `control: 0.5`, `obstacle: 120`) plus soft but lane-viable
-  turn limits (ω̇ 90 °/s²): planners ignore dynamics, so the tracker widens
-  infeasible kinks **inside the road corridor** while `s` advances (see
-  `tools/mpc_progress_first_demo.py`).  A prior 8 m deadzone ate the
-  planner clearance; an over-stiff retune (`control`/`obstacle` too high,
-  ω̇ too low) understeered then hunted — avoid that.  Full post-plan
-  parameter inventory: [control_tracking_params.md](control_tracking_params.md).
+  City uses **progress-first** contouring with **`contour_deadzone: 0`**
+  (`lag: 4`, `control: 0.5`, `obstacle: 120`) plus soft but lane-viable
+  turn limits (ω̇ 90 °/s²): planners ignore dynamics, so lag/progress trade
+  against contour to widen infeasible kinks **inside the road corridor**
+  while `s` advances (see `tools/mpc_progress_first_demo.py`).  A non-zero
+  deadzone flat-zones the lateral cost (zero gradient → equal-cost left/right
+  chatter / wobble); a prior 8 m band also ate planner clearance.  An
+  over-stiff retune (`control`/`obstacle` too high, ω̇ too low) understeered
+  then hunted — avoid that.  Full post-plan parameter inventory:
+  [control_tracking_params.md](control_tracking_params.md).
 - The race renderer draws each racer's **MPC predicted XY polyline** (no tip
   disc) instead of a Pure-Pursuit carrot.
-- Race glyphs stay **oriented rectangles** (`8.0 × 3.6` m half-extents) with
-  soft past / prediction traces (`2.5` / `3.5` px) over the warm SDF road field.
+- Race glyphs stay **oriented rectangles** (`8.0 × 3.6` m half-extents) over
+  the warm SDF road field: dim planned underlay (`2.0` px @ 0.35 α), bold
+  executed past trails (`4.5` px), and prediction polylines (`3.5` px).
 
 ---
 

--- a/docs/VISUALIZATION.md
+++ b/docs/VISUALIZATION.md
@@ -92,6 +92,11 @@ City race notes when `simulator.tracker: mpc`:
 - Race glyphs stay **oriented rectangles** (`8.0 × 3.6` m half-extents) over
   the warm SDF road field: dim planned underlay (`2.0` px @ 0.35 α), bold
   executed past trails (`4.5` px), and prediction polylines (`3.5` px).
+- **Presentation (race phase):** follow-cam zooms to the pack (~200 m window,
+  smoothed chase), a corner **minimap** keeps the full 600 m city, the sidebar
+  switches to **standings** (place / gap / speed), and the header title flips
+  from planning reveal → race · follow cam.  Planning reveal still uses the
+  full bird's-eye map.
 
 ---
 

--- a/docs/control_mpcc.md
+++ b/docs/control_mpcc.md
@@ -126,7 +126,7 @@ Heading stage cost uses a smooth \(2\pi\)-periodic surrogate
 \ell_\psi(e_\psi) = \sin^2 e_\psi + (1-\cos e_\psi)^2.
 \]
 
-**Deadzone (lane-aware free band).**  Only excess lateral error is penalized:
+**Deadzone (optional free band).**  Only excess lateral error is penalized:
 
 \[
 e_{c,k}^{+}
@@ -136,9 +136,10 @@ e_{c,k}^{+}
 d_{\mathrm{dz}} = \texttt{contour\_deadzone}.
 \]
 
-With \(d_{\mathrm{dz}}=0\) this is classical stiff contouring.  City uses a
-*small* \(d_{\mathrm{dz}}\) (\(\ll\) road half-width) so corners may widen
-**inside** the navigable lane without treating clearance as free space.
+With \(d_{\mathrm{dz}}=0\) this is classical quadratic contouring (city
+default).  A non-zero band creates a flat zero-cost / zero-gradient plateau
+where left and right commands share the same lateral cost and can chatter;
+prefer lag/progress tradeoffs for kink widening instead of a free band.
 
 ---
 
@@ -226,9 +227,9 @@ Weights map to `PathFollowingMPCConfig` / YAML `simulator.mpc.weights`:
 | \(d_{\mathrm{dz}}\) | `contour_deadzone` |
 
 Default global `mpc.yml` is **stiff** (\(d_{\mathrm{dz}}=0\), \(w_{\mathrm{lag}}=0\)).
-City overrides are **lane-aware progress-first** (deadzone ≈ 2.5 m,
-moderate lag / contour / obstacle, light control) so corners may widen
-inside the lane without over-constraining \(\dot\omega\).
+City overrides are **progress-first** (\(d_{\mathrm{dz}}=0\), moderate lag /
+contour / obstacle, light control): kink widening comes from the lag vs
+contour tradeoff, not from a flat lateral band.
 
 ### Soft obstacle barriers
 
@@ -328,7 +329,7 @@ cfg = PathFollowingMPCConfig.create_from_config().with_weight_overrides(
     progress=4.0,
     lag=4.0,
     obstacle=120.0,
-    contour_deadzone=2.5,
+    contour_deadzone=0.0,
 )
 mpc = DubinsPathFollowingMPC(vehicle_limits=limits, config=cfg)
 mpc.set_reference([(0.0, 0.0), (40.0, 0.0), (40.0, 40.0)])

--- a/docs/control_tracking_params.md
+++ b/docs/control_tracking_params.md
@@ -83,7 +83,7 @@ Globals: `config/mpc.yml` → `weights` (city overrides only listed keys)
 | YAML key | Config field | Role |
 |----------|--------------|------|
 | `contour` | `weight_contour` | Quadratic penalty on **excess** lateral error outside the deadzone |
-| `contour_deadzone` | `contour_deadzone` | Free band \(\lvert e_{\mathrm{lat}}\rvert \le d_{\mathrm{dz}}\) (m); cost is zero inside |
+| `contour_deadzone` | `contour_deadzone` | Free band \(\lvert e_{\mathrm{lat}}\rvert \le d_{\mathrm{dz}}\) (m); cost is zero inside. **City keeps this at 0** — flats zero the lateral gradient and invite equal-cost left/right chatter |
 | `heading` | `weight_heading` | Heading error vs path tangent |
 | `progress` | `weight_progress` | Track `v_ref` (cruise capped by curve speed) |
 | `lag` | `weight_lag` | Penalty for falling behind virtual progress \(s_0 + v_{\mathrm{cruise}} t\) |
@@ -104,6 +104,9 @@ Barrier shape (not a YAML weight, but couples to `obstacle`):
   understeer, then overshoot when contour finally wins → weave / wall hits.
 - **`contour` high + `contour_deadzone` tiny** → hunts the polyline; on
   jagged A\* paths this looks like zigzag.
+- **`contour_deadzone` > 0** → flat zero-cost band; two commands with the
+  same lateral cost can alternate (wobble / chatter). Prefer `0` and let
+  lag/progress trade against contour for kink widening.
 - **`heading` high** on discontinuous planner yaw → left/right chasing.
 - **`lag` / `progress` high** → prefers advancing \(s\) and holding
   `v_ref`; helps progress-first widening, but can pull through a soft
@@ -112,8 +115,9 @@ Barrier shape (not a YAML weight, but couples to `obstacle`):
   road tube.  Sparse point-cloud samples can still miss a face or fight
   contouring.
 
-City values are scenario YAML; global `mpc.yml` stays classic stiff
-(`contour_deadzone: 0`, `lag: 0`) for non-city demos.
+City values are scenario YAML (`contour_deadzone: 0`, non-zero `lag`);
+global `mpc.yml` stays classic stiff (`contour_deadzone: 0`, `lag: 0`)
+for non-city demos.
 
 ---
 
@@ -225,7 +229,8 @@ Change **one family at a time**; keep the other racers on the same pipeline.
 
 1. **Actuator authority** — `control`, `max_turn_rate`, `max_turn_rate_dot`,
    `max_acceleration` (can the car physically follow a corner?).
-2. **Lane band** — `contour`, `contour_deadzone` (how hard to hug vs widen).
+2. **Lane band** — `contour` first; keep `contour_deadzone = 0` unless you
+   have a strong reason (flats chatter).
 3. **Heading** — reduce if A\*/grid paths zigzag the steer command.
 4. **Progress law** — `progress`, `lag` (advance \(s\) vs nail geometry).
 5. **Soft obstacles** — `obstacle`, barrier power, sample probes
@@ -237,27 +242,28 @@ Change **one family at a time**; keep the other racers on the same pipeline.
 
 ## City defaults vs aggressive stiffen (do not re-apply)
 
-**Current city defaults** (restored lane-viable / progress-first column)
-are shared by blue / green / purple.  The right-hand column is the
-v0.3.5 over-stiff retune — kept only as an anti-pattern.
+**Current city defaults** (progress-first, zero deadzone) are shared by
+blue / green / purple.  The right-hand column is the v0.3.5 over-stiff
+retune — kept only as an anti-pattern.
 
-| Knob | Current (lane-viable) | Aggressive stiffen (avoid) |
-|------|------------------------|----------------------------|
+| Knob | Current (progress-first) | Aggressive stiffen (avoid) |
+|------|--------------------------|----------------------------|
 | `contour` | 8 | 18 |
 | `heading` | 4 | 6 |
 | `control` | 0.5 | 4 |
 | `progress` | 4 | 3 |
 | `lag` | 4 | 2 |
 | `obstacle` | 120 | 280 |
-| `contour_deadzone` | 2.5 m | 1.2 m |
+| `contour_deadzone` | **0 m** | 1.2 m (still a flat band) |
 | `CITY_MAX_TURN_RATE_DOT_DEG` | 90 | 55 |
 | Obstacle NLP samples | pose + path preview (5) | + forward/flank probes (9) |
 | Horizon | 72 × 0.05 s | same |
 
 Raising `control` / obstacle / contour together while cutting \(\dot\omega\)
-and the deadzone often yields **solver “convergence” with poor tracking**:
-understeer into corners, then lateral hunting, then soft-barrier
-penetration.  Nudge **one** knob at a time from the current column.
+often yields **solver “convergence” with poor tracking**: understeer into
+corners, then lateral hunting, then soft-barrier penetration.  A non-zero
+deadzone adds equal-cost chatter inside the flat band.  Nudge **one** knob
+at a time from the current column.
 
 Keep the **κ floor / preview** (`ReferencePath`): that fix is about NLP
 solvability on dense A\* stubs, not about stiffness.

--- a/map/city.yml
+++ b/map/city.yml
@@ -53,21 +53,22 @@ world:
 # follows that arbitrary reference (no replanning inside the tracker).
 simulator:
   tracker: mpc  # "pure_pursuit" (PP+APF) or "mpc" (CasADi path-following NMPC)
-  # Lane-aware progress-first contouring.  Global planners ignore vehicle
-  # dynamics, so the tracker may widen sharp polyline kinks — but only inside
-  # a small free band (≪ road half-width / clearance).  A large deadzone ate
-  # the planner's obstacle clearance and drove cars into walls.  Lag still
-  # prefers advancing s over nailing the kink; contour outside the band keeps
-  # the topological lane.  Global mpc.yml remains stiff (deadzone=0, lag=0).
+  # Progress-first contouring with a strictly quadratic lateral cost.
+  # Global planners ignore vehicle dynamics; lag/progress still prefer
+  # advancing s over nailing sharp polyline kinks.  A non-zero
+  # contour_deadzone creates a flat |e_lat| ≤ d_dz band (zero cost / zero
+  # gradient) where left/right commands share the same cost and chatter —
+  # that flat zone is a common source of race wobble.  Keep d_dz = 0.
+  # Global mpc.yml is also deadzone=0 (and lag=0).
   mpc:
     horizon:
       step_count: 72  # [] prediction steps
       dt: 0.05  # [s] prediction model step
     weights:
-      contour: 8.0  # [] excess-lateral weight outside the deadzone
+      contour: 8.0  # [] lateral contouring weight (quadratic in |e_lat|)
       heading: 4.0  # [] heading tracking (plan has no yaw continuity)
       control: 0.5  # [] control effort — prefer smooth ω
       progress: 4.0  # [] track v_ref (incl. curve-limited corner speed)
       lag: 4.0  # [] behind-schedule progress (do not overpower braking)
       obstacle: 120.0  # [] keep the topological lane clear of buildings
-      contour_deadzone: 2.5  # [m] free |e_lat| band (widen inside the lane)
+      contour_deadzone: 0.0  # [m] no flat lateral band (avoids equal-cost chatter)

--- a/map/city_mpc_preview.yml
+++ b/map/city_mpc_preview.yml
@@ -28,7 +28,7 @@ world:
   seed: 42
 simulator:
   tracker: mpc
-  # Match city.yml: half-block horizon + lane-aware progress-first.
+  # Match city.yml: half-block horizon + progress-first, deadzone=0.
   mpc:
     horizon:
       step_count: 72
@@ -40,4 +40,4 @@ simulator:
       progress: 4.0
       lag: 4.0
       obstacle: 120.0
-      contour_deadzone: 2.5
+      contour_deadzone: 0.0

--- a/src/arco/config/colors.yml
+++ b/src/arco/config/colors.yml
@@ -42,3 +42,9 @@ ui:
   hud_shadow: [40, 40, 50]          # [] text drop shadow (RGB 0-255)
   hud_winner: [255, 215, 50]        # [] winner banner text (RGB 0-255)
   hud_tie: [200, 200, 80]           # [] tie banner text (RGB 0-255)
+  # Shared arcosim chrome (header / footer / sidebar frame).
+  chrome_bar: [16, 18, 26]          # [] header + footer fill (RGB 0-255)
+  chrome_sidebar: [12, 14, 22]      # [] left legend column fill (RGB 0-255)
+  chrome_border: [70, 88, 120]      # [] hairline separators (RGB 0-255)
+  chrome_title: [228, 232, 242]     # [] header title text (RGB 0-255)
+  chrome_hint: [120, 132, 156]      # [] footer hint text (RGB 0-255)

--- a/src/arco/simulator/main/city.py
+++ b/src/arco/simulator/main/city.py
@@ -73,13 +73,14 @@ from arco.simulator.sim.city_race_view import (
     build_race_standings,
     make_minimap_surface,
     pack_centroid,
-    phase_chrome_title,
     race_view_bounds,
 )
 from arco.simulator.sim.layout import (
     ScreenLayout,
+    build_compact_planner_sections,
     draw_sidebar_panel,
     make_chrome_surface,
+    scenario_phase_title,
 )
 from arco.simulator.sim.loading import run_with_loading_screen
 from arco.simulator.sim.tracking import (
@@ -823,21 +824,48 @@ def run_race(
             else:  # done
                 footer_text = "Press  R  to restart   |   Q  to quit"
 
+            method_colors = (_C_RRT_VEH, _C_ASTAR_VEH, _C_SST_VEH)
             chrome_surf = make_chrome_surface(
                 layout,
-                phase_chrome_title(phase),
+                scenario_phase_title("city", phase),
                 footer_text,
                 title_font,
                 font,
+                method_colors=method_colors,
             )
             renderer_gl.blit_overlay(chrome_surf, 0, 0, sw, sh)
 
             if phase == "background":
-                sidebar_sections = scene.sidebar_content(
-                    phase="background",
-                    rrt_revealed=rrt_revealed,
-                    sst_revealed=sst_revealed,
-                    astar_revealed=astar_revealed,
+                sidebar_sections = build_compact_planner_sections(
+                    [
+                        (
+                            "RRT*",
+                            _C_RRT_HUD,
+                            {
+                                **rrt_metrics,
+                                "nodes": rrt_revealed,
+                                "steps": int(rrt_metrics.get("steps", 0)),
+                            },
+                        ),
+                        (
+                            "A*",
+                            _C_ASTAR_HUD,
+                            {
+                                **astar_metrics,
+                                "nodes": astar_revealed,
+                                "steps": int(astar_metrics.get("steps", 0)),
+                            },
+                        ),
+                        (
+                            "SST",
+                            _C_SST_HUD,
+                            {
+                                **sst_metrics,
+                                "nodes": sst_revealed,
+                                "steps": int(sst_metrics.get("steps", 0)),
+                            },
+                        ),
+                    ]
                 )
             else:
                 race_entries: list[

--- a/src/arco/simulator/main/city.py
+++ b/src/arco/simulator/main/city.py
@@ -56,6 +56,7 @@ from arco.config.palette import layer_rgb, ui_rgb
 from arco.simulator import renderer_gl
 from arco.simulator.scenes import RaceScene
 from arco.simulator.scenes.sparse import CityScene
+from arco.simulator.sim.camera import CameraFilter
 from arco.simulator.sim.city_race_style import (
     DEFAULT_CITY_HORIZON_DT,
     DEFAULT_CITY_HORIZON_STEP_COUNT,
@@ -64,6 +65,16 @@ from arco.simulator.sim.city_race_style import (
     PREDICTED_TRACE_WIDTH,
     VEH_HALF_L,
     VEH_HALF_W,
+)
+from arco.simulator.sim.city_race_view import (
+    MINIMAP_PAD_PX,
+    MINIMAP_SIZE_PX,
+    RACE_CAMERA_NATURAL_FREQUENCY,
+    build_race_standings,
+    make_minimap_surface,
+    pack_centroid,
+    phase_chrome_title,
+    race_view_bounds,
 )
 from arco.simulator.sim.layout import (
     ScreenLayout,
@@ -220,10 +231,10 @@ def run_race(
     Phase 1 — **planning reveal**: all exploration trees grow on screen
     simultaneously. The race does not start until every tree is fully drawn.
 
-    Phase 2 — **racing**: all vehicles follow their respective planned paths
-    from a shared start.  The first to arrive is declared the winner.  The
-    simulation continues for :data:`_POST_FINISH_SECS` after the last
-    vehicle reaches the goal, then exits.
+    Phase 2 — **racing**: follow-cam on the pack (corner minimap keeps the
+    full city), standings HUD, vehicles tracking their planned paths from a
+    shared start.  The first to arrive wins.  The simulation continues for
+    :data:`_POST_FINISH_SECS` after the last vehicle reaches the goal.
 
     Args:
         scene: Fully built city race scene.
@@ -287,12 +298,19 @@ def run_race(
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
     glDisable(GL_LIGHTING)
 
-    # World bounds and projection (full fixed view — no follow camera for race).
+    # Full-world bounds for planning reveal; race uses a smoothed follow-cam.
     wpts = scene.world_points
     _all_x = [p[0] for p in wpts]
     _all_y = [p[1] for p in wpts]
     x_min, x_max = min(_all_x), max(_all_x)
     y_min, y_max = min(_all_y), max(_all_y)
+    world_cx = 0.5 * (x_min + x_max)
+    world_cy = 0.5 * (y_min + y_max)
+    race_camera = CameraFilter(
+        world_cx,
+        world_cy,
+        natural_frequency=RACE_CAMERA_NATURAL_FREQUENCY,
+    )
 
     cfg = scene.vehicle_config
     rrt_wps = scene.rrt_waypoints
@@ -427,6 +445,15 @@ def run_race(
                     astar_wps, cfg, occ
                 )
             logger.info("Race started (tracker=%s).", tracker_mode)
+        # Snap follow-cam to the shared start so the first race frames
+        # are already zoomed on the pack (not a slow fly-in from map center).
+        start_xy = None
+        for wps in (rrt_wps, sst_wps, astar_wps):
+            if wps:
+                start_xy = (float(wps[0][0]), float(wps[0][1]))
+                break
+        if start_xy is not None:
+            race_camera.reset(start_xy[0], start_xy[1])
 
     def _restart() -> None:
         nonlocal phase, rrt_revealed, sst_revealed, astar_revealed, hold
@@ -627,9 +654,35 @@ def run_race(
             glClearColor(bg[0] / 255.0, bg[1] / 255.0, bg[2] / 255.0, 1.0)
             glClear(GL_COLOR_BUFFER_BIT)
 
-            # World-space GL (content viewport only)
+            # World-space GL (content viewport only).  Planning = full map;
+            # race / done = follow-cam window around the pack.
+            view_x0, view_x1, view_y0, view_y1 = x_min, x_max, y_min, y_max
+            pack_positions: list[tuple[float, float]] = []
+            if phase in ("racing", "done"):
+                for veh in (rrt_vehicle, sst_vehicle, astar_vehicle):
+                    if veh is not None:
+                        pack_positions.append((float(veh.x), float(veh.y)))
+                if pack_positions:
+                    tx, ty = pack_centroid(pack_positions)
+                    if not paused:
+                        race_camera.update(tx, ty, dt)
+                    view_x0, view_x1, view_y0, view_y1 = race_view_bounds(
+                        race_camera.x,
+                        race_camera.y,
+                        pack_positions,
+                        world_x_min=x_min,
+                        world_x_max=x_max,
+                        world_y_min=y_min,
+                        world_y_max=y_max,
+                    )
+
             renderer_gl.setup_2d_projection(
-                x_min, x_max, y_min, y_max, layout.content_w, layout.content_h
+                view_x0,
+                view_x1,
+                view_y0,
+                view_y1,
+                layout.content_w,
+                layout.content_h,
             )
             layout.setup_content_viewport()
 
@@ -771,7 +824,11 @@ def run_race(
                 footer_text = "Press  R  to restart   |   Q  to quit"
 
             chrome_surf = make_chrome_surface(
-                layout, scene.title, footer_text, title_font, font
+                layout,
+                phase_chrome_title(phase),
+                footer_text,
+                title_font,
+                font,
             )
             renderer_gl.blit_overlay(chrome_surf, 0, 0, sw, sh)
 
@@ -783,14 +840,76 @@ def run_race(
                     astar_revealed=astar_revealed,
                 )
             else:
-                sidebar_sections = scene.sidebar_content(
-                    phase=phase,
-                    race_time=race_time,
-                    rrt_finish=rrt_finish_time,
-                    sst_finish=sst_finish_time,
-                    astar_finish=astar_finish_time,
+                race_entries: list[
+                    tuple[str, tuple[int, int, int], float | None, float]
+                ] = []
+                if rrt_vehicle is not None:
+                    race_entries.append(
+                        (
+                            "RRT*",
+                            _C_RRT_HUD,
+                            rrt_finish_time,
+                            float(rrt_vehicle.speed),
+                        )
+                    )
+                if astar_vehicle is not None:
+                    race_entries.append(
+                        (
+                            "A*",
+                            _C_ASTAR_HUD,
+                            astar_finish_time,
+                            float(astar_vehicle.speed),
+                        )
+                    )
+                if sst_vehicle is not None:
+                    race_entries.append(
+                        (
+                            "SST",
+                            _C_SST_HUD,
+                            sst_finish_time,
+                            float(sst_vehicle.speed),
+                        )
+                    )
+                sidebar_sections = build_race_standings(
+                    race_entries, race_time
                 )
             draw_sidebar_panel(layout, font, sidebar_sections, sw, sh)
+
+            if phase in ("racing", "done") and pack_positions:
+                start_xy = (
+                    (float(rrt_wps[0][0]), float(rrt_wps[0][1]))
+                    if rrt_wps
+                    else pack_positions[0]
+                )
+                goal_xy = (
+                    (float(rrt_wps[-1][0]), float(rrt_wps[-1][1]))
+                    if rrt_wps
+                    else pack_positions[0]
+                )
+                markers: list[tuple[float, float, tuple[int, int, int]]] = []
+                if rrt_vehicle is not None:
+                    markers.append((rrt_vehicle.x, rrt_vehicle.y, _C_RRT_VEH))
+                if sst_vehicle is not None:
+                    markers.append((sst_vehicle.x, sst_vehicle.y, _C_SST_VEH))
+                if astar_vehicle is not None:
+                    markers.append(
+                        (astar_vehicle.x, astar_vehicle.y, _C_ASTAR_VEH)
+                    )
+                minimap = make_minimap_surface(
+                    world_bounds=(x_min, x_max, y_min, y_max),
+                    view_bounds=(view_x0, view_x1, view_y0, view_y1),
+                    markers=markers,
+                    start=start_xy,
+                    goal=goal_xy,
+                )
+                mx = (
+                    layout.content_x
+                    + layout.content_w
+                    - MINIMAP_SIZE_PX
+                    - MINIMAP_PAD_PX
+                )
+                my = sh - layout.footer_h - MINIMAP_SIZE_PX - MINIMAP_PAD_PX
+                renderer_gl.blit_overlay(minimap, mx, my, sw, sh)
 
             if phase in ("racing", "done"):
                 if rrt_finished or sst_finished or astar_finished:

--- a/src/arco/simulator/main/occ.py
+++ b/src/arco/simulator/main/occ.py
@@ -44,6 +44,12 @@ from arco.control import ActuatorArray
 from arco.control.rigid_body import CircleBody, SquareBody
 from arco.mapping import KDTreeOccupancy
 from arco.simulator.scenes.occ import OCCScene
+from arco.simulator.sim.layout import (
+    ScreenLayout,
+    make_chrome_surface,
+    paint_sidebar_panel,
+    scenario_phase_title,
+)
 from arco.simulator.sim.video import VideoWriter
 
 logger = logging.getLogger(__name__)
@@ -433,7 +439,9 @@ def main(cfg: dict, save_path: str | None, sim_duration: float) -> None:
     pygame.display.set_caption("OCC - Piano Movers")
     clock = pygame.time.Clock()
     font = pygame.font.SysFont("monospace", 14)
-    title_font = pygame.font.SysFont("monospace", 18, bold=True)
+    title_font = pygame.font.SysFont("monospace", 16, bold=True)
+    panel_label_font = pygame.font.SysFont("monospace", 18, bold=True)
+    layout = ScreenLayout(_WIDTH, _HEIGHT)
 
     # Build scene with loading screen feedback
     scene = OCCScene(cfg)
@@ -458,9 +466,11 @@ def main(cfg: dict, save_path: str | None, sim_duration: float) -> None:
     x_range = [float(v) for v in env_cfg.get("x_range", [-4, 4])]
     y_range = [float(v) for v in env_cfg.get("y_range", [-3, 3])]
 
-    # Compute scale and origin for one panel (we split width in half)
-    panel_w = _WIDTH // 2
-    panel_h = _HEIGHT
+    # Dual panels live inside the chrome content rect (not the full window).
+    content_x = layout.content_x
+    content_y = layout.header_h
+    panel_w = layout.content_w // 2
+    panel_h = layout.content_h
     x_span = x_range[1] - x_range[0]
     y_span = y_range[1] - y_range[0]
     scale = min(
@@ -470,12 +480,12 @@ def main(cfg: dict, save_path: str | None, sim_duration: float) -> None:
     cx_world = (x_range[0] + x_range[1]) / 2.0
     cy_world = (y_range[0] + y_range[1]) / 2.0
     left_origin = (
-        panel_w // 2 - int(cx_world * scale),
-        panel_h // 2 + int(cy_world * scale),
+        content_x + panel_w // 2 - int(cx_world * scale),
+        content_y + panel_h // 2 + int(cy_world * scale),
     )
     right_origin = (
-        panel_w + panel_w // 2 - int(cx_world * scale),
-        panel_h // 2 + int(cy_world * scale),
+        content_x + panel_w + panel_w // 2 - int(cx_world * scale),
+        content_y + panel_h // 2 + int(cy_world * scale),
     )
 
     # Path tracking state
@@ -646,15 +656,21 @@ def main(cfg: dict, save_path: str | None, sim_duration: float) -> None:
                 if dist < goal_tol:
                     sst_wp_idx = min(sst_wp_idx + 1, len(sst_waypoints))
 
-        # Draw
+        # Draw — content panels inside shared chrome.
         screen.fill(_C_BG)
+        pygame.draw.rect(
+            screen,
+            _C_BG,
+            pygame.Rect(content_x, content_y, layout.content_w, panel_h),
+        )
 
-        # Divider
+        # Divider between RRT* / SST panels (content-relative).
+        mid_x = content_x + panel_w
         pygame.draw.line(
             screen,
             _C_DIVIDER,
-            (panel_w, 0),
-            (panel_w, panel_h),
+            (mid_x, content_y),
+            (mid_x, content_y + panel_h),
             2,
         )
 
@@ -697,10 +713,11 @@ def main(cfg: dict, save_path: str | None, sim_duration: float) -> None:
                 ),
             ]
         ):
+            panel_left = content_x + panel_idx * panel_w
             # Soft method-tint strip under the panel title.
             tint = pygame.Surface((panel_w, 36), pygame.SRCALPHA)
             tint.fill((*body_color, 40))
-            screen.blit(tint, (panel_idx * panel_w, 0))
+            screen.blit(tint, (panel_left, content_y))
 
             # Obstacles
             for obs in obstacles:
@@ -727,17 +744,47 @@ def main(cfg: dict, save_path: str | None, sim_duration: float) -> None:
             _draw_body(screen, body_s, origin, scale, body_color)
 
             # Label
-            lbl = title_font.render(label, True, _C_HUD)
-            screen.blit(lbl, (panel_idx * panel_w + 10, 10))
+            lbl = panel_label_font.render(label, True, _C_HUD)
+            screen.blit(lbl, (panel_left + 10, content_y + 10))
 
-        # Status bar
-        status = "PAUSED" if paused else "RUNNING"
-        info = font.render(
-            f"{status} | SPACE=pause  R=restart  Q=quit",
-            True,
-            _C_HUD_DIM,
+        phase_key = "paused" if paused else "running"
+        footer = (
+            "PAUSED  ·  SPACE resume  ·  R restart  ·  Q quit"
+            if paused
+            else "RUNNING  ·  SPACE pause  ·  R restart  ·  Q quit"
         )
-        screen.blit(info, (10, panel_h - 24))
+        chrome = make_chrome_surface(
+            layout,
+            scenario_phase_title("occ", phase_key),
+            footer,
+            title_font,
+            font,
+            method_colors=(_C_RRT_BODY, _C_SST_BODY),
+        )
+        screen.blit(chrome, (0, 0))
+        paint_sidebar_panel(
+            screen,
+            layout,
+            font,
+            [
+                (
+                    [
+                        "RRT*",
+                        "  left panel",
+                        "  path + PD track",
+                    ],
+                    _C_RRT_BODY,
+                ),
+                (
+                    [
+                        "SST",
+                        "  right panel",
+                        "  path + PD track",
+                    ],
+                    _C_SST_BODY,
+                ),
+            ],
+        )
 
         pygame.display.flip()
 

--- a/src/arco/simulator/main/ppp.py
+++ b/src/arco/simulator/main/ppp.py
@@ -108,12 +108,21 @@ from arco.config import load_config
 from arco.config.palette import (
     annotation_rgb,
     layer_float,
+    layer_rgb,
     obstacle_float,
     ui_rgb,
 )
+from arco.simulator import renderer_gl
 from arco.simulator.scenes.ppp import BOUNDS as _SCENE_BOUNDS
 from arco.simulator.scenes.ppp import PPPScene
 from arco.simulator.scenes.ppp import is_wall as _is_wall_box
+from arco.simulator.sim.layout import (
+    ScreenLayout,
+    build_compact_planner_sections,
+    draw_sidebar_panel,
+    make_chrome_surface,
+    scenario_phase_title,
+)
 from arco.simulator.sim.loading import run_with_loading_screen
 from arco.simulator.sim.tracking import build_joint_tracker
 from arco.simulator.sim.video import VideoWriter
@@ -259,9 +268,9 @@ _ann = annotation_rgb(dark_bg=True)
 _C_START = (_ann[0] / 255.0, _ann[1] / 255.0, _ann[2] / 255.0)
 _C_GOAL = layer_float("rrt", "vehicle")
 
-# HUD colors (pygame RGB int 0-255)
-_HC_RRT = ui_rgb("hud_text")
-_HC_SST = ui_rgb("hud_text")
+# HUD colors (pygame RGB int 0-255) — method colors restored for the legend.
+_HC_RRT = layer_rgb("rrt", "vehicle")
+_HC_SST = layer_rgb("sst", "vehicle")
 _HC_HUD = ui_rgb("hud_text")
 _HC_DIM = ui_rgb("hud_dim")
 _HC_SHADOW = ui_rgb("hud_shadow")
@@ -357,6 +366,18 @@ def _gl_init(sw: int, sh: int) -> None:
     glMatrixMode(GL_PROJECTION)
     glLoadIdentity()
     glMultMatrixf(_perspective_matrix(45.0, sw / max(sh, 1), 0.1, 1000.0))
+    glMatrixMode(GL_MODELVIEW)
+
+
+def _set_perspective(aspect: float) -> None:
+    """Refresh the perspective projection for the current content aspect.
+
+    Args:
+        aspect: Viewport width / height.
+    """
+    glMatrixMode(GL_PROJECTION)
+    glLoadIdentity()
+    glMultMatrixf(_perspective_matrix(45.0, max(aspect, 1e-3), 0.1, 1000.0))
     glMatrixMode(GL_MODELVIEW)
 
 
@@ -1006,9 +1027,9 @@ def run_race(
     pygame.display.set_caption(scene.title)
 
     font = pygame.font.SysFont("monospace", 14)
+    title_font = pygame.font.SysFont("monospace", 16, bold=True)
     big_font = pygame.font.SysFont("monospace", 40, bold=True)
-    hint_surf = _hint_surface(font)
-
+    layout = ScreenLayout(sw, sh)
     camera = Camera3D()
     rrt_path = scene.rrt_path  # pruned waypoints
     sst_path = scene.sst_path  # pruned waypoints
@@ -1180,8 +1201,10 @@ def run_race(
                     if recording and post_timer >= _POST_FINISH_SECS:
                         running = False
 
-            # --- 3-D render (OpenGL) ------------------------------------
+            # --- 3-D render (OpenGL, content column only) --------------
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
+            layout.setup_content_viewport()
+            _set_perspective(layout.content_w / max(layout.content_h, 1))
             _set_camera(camera)
 
             _draw_floor_grid(scene.bounds[0][1], scene.bounds[1][1])
@@ -1261,37 +1284,73 @@ def run_race(
                 _draw_effector(rrt_robot.q, *_C_TRAIL_RRT)
                 _draw_effector(sst_robot.q, *_C_TRAIL_SST)
 
-            # --- 2-D HUD overlay ----------------------------------------
-            _blit_overlay(
-                _status_surface(
-                    font,
-                    rrt_metrics,
-                    sst_metrics,
-                    phase,
-                    max(0.0, _HOLD_SECS - hold_timer),
-                ),
-                8,
-                8,
-                sw,
-                sh,
+            # --- Shared chrome + sidebar (full window) -----------------
+            layout.reset_viewport()
+            if phase == "show":
+                footer = (
+                    f"[ PAUSED ]"
+                    if paused
+                    else f"Path reveal  ·  race in {max(0.0, _HOLD_SECS - hold_timer):.1f} s"
+                )
+            elif phase == "race":
+                footer = "[ PAUSED ]" if paused else "Race"
+            else:
+                footer = "Press  R  to restart   |   Q  to quit"
+            chrome = make_chrome_surface(
+                layout,
+                scenario_phase_title("ppp", phase),
+                footer,
+                title_font,
+                font,
+                method_colors=(_HC_RRT, _HC_SST),
             )
-            _blit_overlay(
-                hint_surf,
-                (sw - hint_surf.get_width()) // 2,
-                sh - hint_surf.get_height() - 6,
-                sw,
-                sh,
-            )
+            renderer_gl.blit_overlay(chrome, 0, 0, sw, sh)
+
+            if phase == "show":
+                sections = build_compact_planner_sections(
+                    [
+                        ("RRT*", _HC_RRT, rrt_metrics),
+                        ("SST", _HC_SST, sst_metrics),
+                    ]
+                )
+            else:
+                sections = [
+                    (
+                        [
+                            "STANDINGS",
+                            f"  {'PAUSED' if paused else 'live'}",
+                        ],
+                        _HC_HUD,
+                    ),
+                    (
+                        [
+                            "RRT*",
+                            f"  {'GOAL' if rrt_done else 'racing'}",
+                        ],
+                        _HC_RRT,
+                    ),
+                    (
+                        [
+                            "SST",
+                            f"  {'GOAL' if sst_done else 'racing'}",
+                        ],
+                        _HC_SST,
+                    ),
+                ]
+            draw_sidebar_panel(layout, font, sections, sw, sh)
+
             if winner:
                 w_color = _HC_TIE if winner == "TIE!" else _HC_WINNER
                 ban = _banner_surface(big_font, winner, w_color)
-                _blit_overlay(
-                    ban,
-                    (sw - ban.get_width()) // 2,
-                    (sh - ban.get_height()) // 2,
-                    sw,
-                    sh,
+                bx = (
+                    layout.content_x
+                    + (layout.content_w - ban.get_width()) // 2
                 )
+                by = (
+                    layout.header_h
+                    + (layout.content_h - ban.get_height()) // 2
+                )
+                renderer_gl.blit_overlay(ban, bx, by, sw, sh)
 
             pygame.display.flip()
 

--- a/src/arco/simulator/main/rrp.py
+++ b/src/arco/simulator/main/rrp.py
@@ -111,10 +111,19 @@ from arco.config import load_config
 from arco.config.palette import (
     annotation_rgb,
     layer_float,
+    layer_rgb,
     obstacle_float,
     ui_rgb,
 )
+from arco.simulator import renderer_gl
 from arco.simulator.scenes.rrp import RRPScene
+from arco.simulator.sim.layout import (
+    ScreenLayout,
+    build_compact_planner_sections,
+    draw_sidebar_panel,
+    make_chrome_surface,
+    scenario_phase_title,
+)
 from arco.simulator.sim.loading import run_with_loading_screen
 from arco.simulator.sim.tracking import build_joint_tracker
 from arco.simulator.sim.video import VideoWriter
@@ -242,9 +251,9 @@ _C_LINK2_RRT = layer_float("rrt", "pruned")
 _C_LINK1_SST = layer_float("sst", "vehicle")
 _C_LINK2_SST = layer_float("sst", "pruned")
 
-# HUD colors (pygame RGB int 0-255)
-_HC_RRT = ui_rgb("hud_text")
-_HC_SST = ui_rgb("hud_text")
+# HUD colors (pygame RGB int 0-255) — method colors restored for the legend.
+_HC_RRT = layer_rgb("rrt", "vehicle")
+_HC_SST = layer_rgb("sst", "vehicle")
 _HC_HUD = ui_rgb("hud_text")
 _HC_DIM = ui_rgb("hud_dim")
 _HC_SHADOW = ui_rgb("hud_shadow")
@@ -353,6 +362,18 @@ def _gl_init(sw: int, sh: int) -> None:
     glMatrixMode(GL_PROJECTION)
     glLoadIdentity()
     glMultMatrixf(_perspective_matrix(45.0, sw / max(sh, 1), 0.01, 200.0))
+    glMatrixMode(GL_MODELVIEW)
+
+
+def _set_perspective(aspect: float) -> None:
+    """Refresh the perspective projection for the current content aspect.
+
+    Args:
+        aspect: Viewport width / height.
+    """
+    glMatrixMode(GL_PROJECTION)
+    glLoadIdentity()
+    glMultMatrixf(_perspective_matrix(45.0, max(aspect, 1e-3), 0.01, 200.0))
     glMatrixMode(GL_MODELVIEW)
 
 
@@ -969,8 +990,9 @@ def run_race(
     pygame.display.set_caption(scene.title)
 
     font = pygame.font.SysFont("monospace", 14)
+    title_font = pygame.font.SysFont("monospace", 16, bold=True)
     big_font = pygame.font.SysFont("monospace", 40, bold=True)
-    hint_surf = _hint_surface(font)
+    layout = ScreenLayout(sw, sh)
 
     camera = Camera3D()
     robot = scene.robot
@@ -1150,10 +1172,12 @@ def run_race(
                     if recording and post_timer >= _POST_FINISH_SECS:
                         running = False
 
-            # --- 3-D render (OpenGL) ---
+            # --- 3-D render (OpenGL, content column only) ---
             from OpenGL.GL import GL_DEPTH_BUFFER_BIT
 
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
+            layout.setup_content_viewport()
+            _set_perspective(layout.content_w / max(layout.content_h, 1))
             _set_camera(camera)
 
             _draw_grid_xy(robot.workspace_radius())
@@ -1265,37 +1289,76 @@ def run_race(
                     _C_LINK2_SST,
                 )
 
-            # --- 2-D HUD overlay ---
-            _blit_overlay(
-                _status_surface(
-                    font,
-                    rrt_metrics,
-                    sst_metrics,
-                    phase,
-                    max(0.0, _HOLD_SECS - hold_timer),
-                ),
-                8,
-                8,
-                sw,
-                sh,
+            # --- Shared chrome + sidebar (full window) ---
+            layout.reset_viewport()
+            if phase == "show":
+                footer = (
+                    "[ PAUSED ]"
+                    if paused
+                    else (
+                        "Path reveal  ·  race in "
+                        f"{max(0.0, _HOLD_SECS - hold_timer):.1f} s"
+                    )
+                )
+            elif phase == "race":
+                footer = "[ PAUSED ]" if paused else "Race"
+            else:
+                footer = "Press  R  to restart   |   Q  to quit"
+            chrome = make_chrome_surface(
+                layout,
+                scenario_phase_title("rrp", phase),
+                footer,
+                title_font,
+                font,
+                method_colors=(_HC_RRT, _HC_SST),
             )
-            _blit_overlay(
-                hint_surf,
-                (sw - hint_surf.get_width()) // 2,
-                sh - hint_surf.get_height() - 6,
-                sw,
-                sh,
-            )
+            renderer_gl.blit_overlay(chrome, 0, 0, sw, sh)
+
+            if phase == "show":
+                sections = build_compact_planner_sections(
+                    [
+                        ("RRT*", _HC_RRT, rrt_metrics),
+                        ("SST", _HC_SST, sst_metrics),
+                    ]
+                )
+            else:
+                sections = [
+                    (
+                        [
+                            "STANDINGS",
+                            f"  {'PAUSED' if paused else 'live'}",
+                        ],
+                        _HC_HUD,
+                    ),
+                    (
+                        [
+                            "RRT*",
+                            f"  {'GOAL' if rrt_done else 'racing'}",
+                        ],
+                        _HC_RRT,
+                    ),
+                    (
+                        [
+                            "SST",
+                            f"  {'GOAL' if sst_done else 'racing'}",
+                        ],
+                        _HC_SST,
+                    ),
+                ]
+            draw_sidebar_panel(layout, font, sections, sw, sh)
+
             if winner:
                 w_color = _HC_TIE if winner == "TIE!" else _HC_WINNER
                 ban = _banner_surface(big_font, winner, w_color)
-                _blit_overlay(
-                    ban,
-                    (sw - ban.get_width()) // 2,
-                    (sh - ban.get_height()) // 2,
-                    sw,
-                    sh,
+                bx = (
+                    layout.content_x
+                    + (layout.content_w - ban.get_width()) // 2
                 )
+                by = (
+                    layout.header_h
+                    + (layout.content_h - ban.get_height()) // 2
+                )
+                renderer_gl.blit_overlay(ban, bx, by, sw, sh)
 
             pygame.display.flip()
 

--- a/src/arco/simulator/scenes/sparse.py
+++ b/src/arco/simulator/scenes/sparse.py
@@ -704,8 +704,8 @@ class CityScene(RaceScene):
 
     @property
     def title(self) -> str:
-        """Window caption."""
-        return "RRT* vs SST vs A* — neighborhood race"
+        """Window caption (chrome overrides with phase-specific titles)."""
+        return "City — RRT* / SST / A*"
 
     @property
     def bg_color(self) -> tuple[int, int, int]:

--- a/src/arco/simulator/scenes/sparse.py
+++ b/src/arco/simulator/scenes/sparse.py
@@ -38,7 +38,11 @@ from scipy.spatial import Delaunay as _Delaunay
 
 from arco.config.palette import annotation_rgb, layer_rgb, obstacle_rgb, ui_rgb
 from arco.simulator import renderer_gl
-from arco.simulator.sim.city_race_style import make_city_vehicle_config
+from arco.simulator.sim.city_race_style import (
+    PLANNED_ROUTE_ALPHA,
+    PLANNED_ROUTE_WIDTH,
+    make_city_vehicle_config,
+)
 from arco.simulator.sim.scene import RaceScene
 from arco.simulator.sim.tracking import VehicleConfig
 
@@ -819,9 +823,9 @@ class CityScene(RaceScene):
         heatmap, road markings, buildings, barriers, exploration trees, raw
         planned paths, and optimized trajectories.
 
-        When *racing* is ``True`` only the adjusted (optimized) trajectories
-        and the start/goal markers are rendered, giving a clean view of the
-        routes the vehicles are tracking.
+        When *racing* is ``True`` the warm SDF road field stays on, with
+        road dots, buildings, and **dimmed** planned routes so the live
+        executed traces (drawn by the race loop) remain the visual hero.
 
         Args:
             rrt_revealed: Number of RRT* tree nodes to display (ignored when
@@ -830,8 +834,8 @@ class CityScene(RaceScene):
                 *racing* is ``True``).
             astar_revealed: Number of A* tree nodes to display (ignored when
                 *racing* is ``True``).
-            racing: When ``True``, collapse the view to only the adjusted
-                trajectories and start/goal markers.
+            racing: When ``True``, keep the SDF backdrop and dim planned
+                routes for the race overlay.
         """
         x_min, x_max = self._bounds[0]
         y_min, y_max = self._bounds[1]
@@ -976,14 +980,16 @@ class CityScene(RaceScene):
                 renderer_gl.draw_path(
                     rrt_route,
                     *_c(_C_RRT_TRAJ),
-                    width=3.0,
+                    width=PLANNED_ROUTE_WIDTH,
+                    alpha=PLANNED_ROUTE_ALPHA,
                 )
             sst_route = self._sst_traj_states or self._sst_path
             if sst_route:
                 renderer_gl.draw_path(
                     sst_route,
                     *_c(_C_SST_TRAJ),
-                    width=3.0,
+                    width=PLANNED_ROUTE_WIDTH,
+                    alpha=PLANNED_ROUTE_ALPHA,
                 )
 
             astar_route = self._astar_traj_states or self._astar_path
@@ -991,7 +997,8 @@ class CityScene(RaceScene):
                 renderer_gl.draw_path(
                     astar_route,
                     *_c(_C_ASTAR_TRAJ),
-                    width=3.0,
+                    width=PLANNED_ROUTE_WIDTH,
+                    alpha=PLANNED_ROUTE_ALPHA,
                 )
 
         # Start/goal markers — always visible.

--- a/src/arco/simulator/sim/city_race_style.py
+++ b/src/arco/simulator/sim/city_race_style.py
@@ -22,12 +22,16 @@ VEH_HALF_W: float = 3.6
 # Small Pure-Pursuit carrot disc only (meters).  Never used as the racer glyph.
 LOOKAHEAD_DISC_R: float = 1.5
 
-# Past executed trajectory line width in pixels — softer than the route so
-# the planned lane stays readable under three overlapping racers.
-PAST_TRACE_WIDTH: float = 2.5
+# Past executed trajectory line width in pixels — bold hero trail so the
+# race path reads clearly over the dimmed planned route.
+PAST_TRACE_WIDTH: float = 4.5
 
-# MPC predicted-horizon polyline width in pixels (slightly thicker than past).
+# MPC predicted-horizon polyline width in pixels (between plan and past).
 PREDICTED_TRACE_WIDTH: float = 3.5
+
+# Planned route underlay during the race phase (dimmed so past traces pop).
+PLANNED_ROUTE_WIDTH: float = 2.0
+PLANNED_ROUTE_ALPHA: float = 0.35
 
 # Default city-demo prediction horizon when scenario YAML omits an override.
 # 72 × 0.05 s = 3.6 s (~43 m at the soft city cruise of 12 m/s) — about half
@@ -39,9 +43,9 @@ DEFAULT_CITY_HORIZON_DT: float = 0.05
 # ω̇≈∞, a=4.9, cruise=18) let the NMPC nail A* kinks then reverse progress.
 # The first soft pass (ω=30°/s, cruise=14 → R_min≈27 m) made understeer
 # visible but *forced* corner cuts outside the 15 m road half-width when
-# curve-speed limiting failed.  These bounds keep turns soft while a
-# corrected polyline κ + small contour deadzone let the car slow and widen
-# *inside* the navigable lane.
+# curve-speed limiting failed.  These bounds keep turns soft while
+# corrected polyline κ + lag/progress (deadzone=0) let the car slow and
+# trade contour cost for progress *inside* the navigable lane.
 CITY_MAX_SPEED: float = 16.0
 CITY_CRUISE_SPEED: float = 12.0
 CITY_MAX_TURN_RATE_DEG: float = 40.0

--- a/src/arco/simulator/sim/city_race_view.py
+++ b/src/arco/simulator/sim/city_race_view.py
@@ -134,8 +134,10 @@ def build_race_standings(
     for name, color, speed in active:
         ordered.append((name, color, None, speed))
 
+    from arco.config.palette import ui_rgb
+
     leader_time = finished[0][2] if finished else None
-    header_color = (200, 210, 230)
+    header_color = ui_rgb("chrome_title")
     sections: list[tuple[list[str], tuple[int, int, int]]] = [
         (
             [
@@ -189,16 +191,24 @@ def make_minimap_surface(
     """
     import pygame
 
+    from arco.config.palette import ui_rgb
+
     wx0, wx1, wy0, wy1 = world_bounds
     world_w = max(wx1 - wx0, 1e-6)
     world_h = max(wy1 - wy0, 1e-6)
     pad = 8
     inner = max(size_px - 2 * pad, 8)
 
+    bar = ui_rgb("chrome_bar")
+    border = ui_rgb("chrome_border")
+    mark = ui_rgb("chrome_title")
     surf = pygame.Surface((size_px, size_px), pygame.SRCALPHA)
-    surf.fill((8, 10, 16, 210))
+    surf.fill((bar[0], bar[1], bar[2], 210))
     pygame.draw.rect(
-        surf, (55, 70, 100, 255), pygame.Rect(0, 0, size_px, size_px), 1
+        surf,
+        (border[0], border[1], border[2], 255),
+        pygame.Rect(0, 0, size_px, size_px),
+        1,
     )
 
     def _to_px(x: float, y: float) -> tuple[int, int]:
@@ -218,12 +228,12 @@ def make_minimap_surface(
         _to_px(vx1, vy1),
         _to_px(vx0, vy1),
     ]
-    pygame.draw.polygon(surf, (180, 190, 210, 90), corners, 1)
+    pygame.draw.polygon(surf, (mark[0], mark[1], mark[2], 90), corners, 1)
 
     sx, sy = _to_px(start[0], start[1])
     gx, gy = _to_px(goal[0], goal[1])
-    pygame.draw.circle(surf, (240, 240, 240), (sx, sy), 3)
-    pygame.draw.circle(surf, (240, 240, 240), (gx, gy), 3, 1)
+    pygame.draw.circle(surf, mark, (sx, sy), 3)
+    pygame.draw.circle(surf, mark, (gx, gy), 3, 1)
 
     for x, y, color in markers:
         px, py = _to_px(x, y)
@@ -235,14 +245,14 @@ def make_minimap_surface(
 def phase_chrome_title(phase: str) -> str:
     """Return the header title for the current city presentation phase.
 
+    Deprecated alias for :func:`scenario_phase_title` — kept for tests.
+
     Args:
         phase: ``background``, ``racing``, or ``done``.
 
     Returns:
         Short title string for the chrome header.
     """
-    if phase == "background":
-        return "City — planning reveal"
-    if phase == "racing":
-        return "City — race · follow cam"
-    return "City — race complete"
+    from arco.simulator.sim.layout import scenario_phase_title
+
+    return scenario_phase_title("city", phase)

--- a/src/arco/simulator/sim/city_race_view.py
+++ b/src/arco/simulator/sim/city_race_view.py
@@ -1,0 +1,248 @@
+"""City race presentation: follow-cam framing, standings HUD, minimap.
+
+Planning reveal stays on the full neighborhood map.  During the race the
+main viewport zooms to the pack (smooth chase) and a corner minimap keeps
+the full city readable — a real presentation change vs a static bird's-eye.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Sequence
+
+if TYPE_CHECKING:
+    import pygame
+
+# Zoomed race window half-size floor (m).  ~200 m across ≈ 1.5 city blocks.
+RACE_VIEW_MIN_HALF_EXTENT: float = 100.0
+# Extra pad around the pack bounding box before choosing half-extent (m).
+RACE_VIEW_MARGIN: float = 45.0
+# Critically-damped chase — slower than the default 3 rad/s for a calmer race feel.
+RACE_CAMERA_NATURAL_FREQUENCY: float = 1.8
+# Corner minimap (pixels) and inset from the content edges.
+MINIMAP_SIZE_PX: int = 176
+MINIMAP_PAD_PX: int = 12
+
+
+def pack_centroid(
+    positions: Sequence[tuple[float, float]],
+) -> tuple[float, float]:
+    """Return the mean XY of *positions*, or ``(0, 0)`` if empty.
+
+    Args:
+        positions: World-frame ``(x, y)`` samples (active racers).
+
+    Returns:
+        Centroid ``(x, y)`` in meters.
+    """
+    if not positions:
+        return (0.0, 0.0)
+    n = float(len(positions))
+    return (
+        sum(p[0] for p in positions) / n,
+        sum(p[1] for p in positions) / n,
+    )
+
+
+def race_view_bounds(
+    center_x: float,
+    center_y: float,
+    positions: Sequence[tuple[float, float]],
+    *,
+    world_x_min: float,
+    world_x_max: float,
+    world_y_min: float,
+    world_y_max: float,
+    min_half_extent: float = RACE_VIEW_MIN_HALF_EXTENT,
+    margin: float = RACE_VIEW_MARGIN,
+) -> tuple[float, float, float, float]:
+    """Compute a square orthographic window around the chase camera.
+
+    The half-extent is at least *min_half_extent* and grows to fit the pack
+    plus *margin*.  The window is then shifted to stay inside the world box
+    when possible.
+
+    Args:
+        center_x: Filtered camera center x (m).
+        center_y: Filtered camera center y (m).
+        positions: Racer positions used to size the window.
+        world_x_min: World left edge (m).
+        world_x_max: World right edge (m).
+        world_y_min: World bottom edge (m).
+        world_y_max: World top edge (m).
+        min_half_extent: Minimum half-width / half-height (m).
+        margin: Extra pad around the pack AABB (m).
+
+    Returns:
+        ``(x_min, x_max, y_min, y_max)`` in world meters.
+    """
+    half = float(min_half_extent)
+    if positions:
+        xs = [p[0] for p in positions]
+        ys = [p[1] for p in positions]
+        span = max(max(xs) - min(xs), max(ys) - min(ys))
+        half = max(half, 0.5 * span + float(margin))
+
+    world_w = world_x_max - world_x_min
+    world_h = world_y_max - world_y_min
+    half = min(half, 0.5 * max(world_w, world_h))
+
+    x0 = center_x - half
+    x1 = center_x + half
+    y0 = center_y - half
+    y1 = center_y + half
+
+    if x0 < world_x_min:
+        shift = world_x_min - x0
+        x0 += shift
+        x1 += shift
+    if x1 > world_x_max:
+        shift = x1 - world_x_max
+        x0 -= shift
+        x1 -= shift
+    if y0 < world_y_min:
+        shift = world_y_min - y0
+        y0 += shift
+        y1 += shift
+    if y1 > world_y_max:
+        shift = y1 - world_y_max
+        y0 -= shift
+        y1 -= shift
+
+    return (x0, x1, y0, y1)
+
+
+def build_race_standings(
+    entries: Sequence[tuple[str, tuple[int, int, int], float | None, float]],
+    race_time: float,
+) -> list[tuple[list[str], tuple[int, int, int]]]:
+    """Build sidebar sections: standings header + per-racer place / gap / speed.
+
+    Args:
+        entries: ``(name, color, finish_time_or_None, speed_m_s)`` per racer.
+        race_time: Elapsed race clock (s).
+
+    Returns:
+        Sidebar ``(lines, color)`` sections for :func:`draw_sidebar_panel`.
+    """
+    finished = [(n, c, float(t), s) for n, c, t, s in entries if t is not None]
+    active = [(n, c, s) for n, c, t, s in entries if t is None]
+    finished.sort(key=lambda row: row[2])
+
+    ordered: list[tuple[str, tuple[int, int, int], float | None, float]] = []
+    for name, color, finish, speed in finished:
+        ordered.append((name, color, finish, speed))
+    for name, color, speed in active:
+        ordered.append((name, color, None, speed))
+
+    leader_time = finished[0][2] if finished else None
+    header_color = (200, 210, 230)
+    sections: list[tuple[list[str], tuple[int, int, int]]] = [
+        (
+            [
+                "STANDINGS",
+                f"  clock  {race_time:.1f} s",
+            ],
+            header_color,
+        )
+    ]
+    for place, (name, color, finish, speed) in enumerate(ordered, start=1):
+        if finish is not None:
+            gap = ""
+            if leader_time is not None and place > 1:
+                gap = f"  (+{finish - leader_time:.1f})"
+            status = f"GOAL {finish:.1f}s{gap}"
+        else:
+            status = f"racing · {speed:.1f} m/s"
+        sections.append(
+            (
+                [
+                    f"{place}  {name}",
+                    f"  {status}",
+                ],
+                color,
+            )
+        )
+    return sections
+
+
+def make_minimap_surface(
+    *,
+    world_bounds: tuple[float, float, float, float],
+    view_bounds: tuple[float, float, float, float],
+    markers: Sequence[tuple[float, float, tuple[int, int, int]]],
+    start: tuple[float, float],
+    goal: tuple[float, float],
+    size_px: int = MINIMAP_SIZE_PX,
+) -> "pygame.Surface":
+    """Render a dark inset map of the full city with view frame and racers.
+
+    Args:
+        world_bounds: Full map ``(x_min, x_max, y_min, y_max)``.
+        view_bounds: Current follow-cam window (same tuple shape).
+        markers: ``(x, y, rgb)`` racer dots.
+        start: Start marker world position.
+        goal: Goal marker world position.
+        size_px: Square minimap edge length in pixels.
+
+    Returns:
+        A ``pygame.Surface`` (SRCALPHA) ready for :func:`blit_overlay`.
+    """
+    import pygame
+
+    wx0, wx1, wy0, wy1 = world_bounds
+    world_w = max(wx1 - wx0, 1e-6)
+    world_h = max(wy1 - wy0, 1e-6)
+    pad = 8
+    inner = max(size_px - 2 * pad, 8)
+
+    surf = pygame.Surface((size_px, size_px), pygame.SRCALPHA)
+    surf.fill((8, 10, 16, 210))
+    pygame.draw.rect(
+        surf, (55, 70, 100, 255), pygame.Rect(0, 0, size_px, size_px), 1
+    )
+
+    def _to_px(x: float, y: float) -> tuple[int, int]:
+        u = (x - wx0) / world_w
+        v = (y - wy0) / world_h
+        # pygame y grows downward; world y grows upward.
+        return (
+            pad + int(u * inner),
+            pad + int((1.0 - v) * inner),
+        )
+
+    # Follow-cam frame on the full map.
+    vx0, vx1, vy0, vy1 = view_bounds
+    corners = [
+        _to_px(vx0, vy0),
+        _to_px(vx1, vy0),
+        _to_px(vx1, vy1),
+        _to_px(vx0, vy1),
+    ]
+    pygame.draw.polygon(surf, (180, 190, 210, 90), corners, 1)
+
+    sx, sy = _to_px(start[0], start[1])
+    gx, gy = _to_px(goal[0], goal[1])
+    pygame.draw.circle(surf, (240, 240, 240), (sx, sy), 3)
+    pygame.draw.circle(surf, (240, 240, 240), (gx, gy), 3, 1)
+
+    for x, y, color in markers:
+        px, py = _to_px(x, y)
+        pygame.draw.circle(surf, color, (px, py), 4)
+
+    return surf
+
+
+def phase_chrome_title(phase: str) -> str:
+    """Return the header title for the current city presentation phase.
+
+    Args:
+        phase: ``background``, ``racing``, or ``done``.
+
+    Returns:
+        Short title string for the chrome header.
+    """
+    if phase == "background":
+        return "City — planning reveal"
+    if phase == "racing":
+        return "City — race · follow cam"
+    return "City — race complete"

--- a/src/arco/simulator/sim/layout.py
+++ b/src/arco/simulator/sim/layout.py
@@ -1,16 +1,24 @@
-"""Two-column screen layout geometry for arcosim.
+"""Shared arcosim presentation chrome (header / sidebar / footer).
 
-Defines :class:`ScreenLayout` (geometry) and helpers for drawing the
-header / footer / sidebar chrome and the sidebar text panel.
+All four primary scenarios (city, ppp, rrp, occ) compose their on-screen
+shell through :class:`ScreenLayout` and the helpers below so release videos
+share one layout language: left legend, phase title, method accent stripe,
+footer hints.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Sequence
 
 if TYPE_CHECKING:
     import pygame
+
+# Default chrome geometry — taller header + wider sidebar than the old 40/260.
+_DEFAULT_SIDEBAR_W = 280
+_DEFAULT_HEADER_H = 44
+_DEFAULT_FOOTER_H = 32
+_METHOD_STRIPE_H = 3
 
 
 @dataclass
@@ -22,16 +30,15 @@ class ScreenLayout:
 
     .. code-block:: text
 
-        ┌───────────────────────────────────────┐  ← header_h (40 px)
-        │               Header                  │
-        ├─────────────┬─────────────────────────┤
-        │             │                         │
-        │   Sidebar   │       Content           │
-        │  (sidebar_w)│  (content_w × content_h)│
-        │             │                         │
-        ├─────────────┴─────────────────────────┤  ← footer_h (30 px)
-        │               Footer                  │
-        └───────────────────────────────────────┘
+        +---------------------------------------+  <- header (+ method stripe)
+        |  Title                                |
+        +-------------+-------------------------+
+        |             |                         |
+        |   Sidebar   |       Content           |
+        |             |                         |
+        +-------------+-------------------------+  <- footer
+        |               Footer                  |
+        +---------------------------------------+
 
     Args:
         sw: Screen width in pixels.
@@ -43,9 +50,9 @@ class ScreenLayout:
 
     sw: int
     sh: int
-    sidebar_w: int = 260
-    header_h: int = 40
-    footer_h: int = 30
+    sidebar_w: int = _DEFAULT_SIDEBAR_W
+    header_h: int = _DEFAULT_HEADER_H
+    footer_h: int = _DEFAULT_FOOTER_H
 
     @property
     def content_x(self) -> int:
@@ -94,24 +101,99 @@ class ScreenLayout:
         glViewport(0, 0, self.sw, self.sh)
 
 
+def scenario_phase_title(scenario: str, phase: str) -> str:
+    """Return a short header title for a scenario presentation phase.
+
+    Args:
+        scenario: One of ``city``, ``ppp``, ``rrp``, ``occ``.
+        phase: Scenario-local phase key (``background`` / ``racing`` /
+            ``show`` / ``race`` / ``done`` / ``running`` …).
+
+    Returns:
+        Title string for the chrome header.
+    """
+    key = (scenario.lower().strip(), phase.lower().strip())
+    table: dict[tuple[str, str], str] = {
+        ("city", "background"): "City  ·  planning reveal",
+        ("city", "racing"): "City  ·  race",
+        ("city", "done"): "City  ·  finished",
+        ("ppp", "show"): "PPP  ·  path reveal",
+        ("ppp", "race"): "PPP  ·  race",
+        ("ppp", "done"): "PPP  ·  finished",
+        ("rrp", "show"): "RRP  ·  path reveal",
+        ("rrp", "race"): "RRP  ·  race",
+        ("rrp", "done"): "RRP  ·  finished",
+        ("occ", "running"): "OCC  ·  piano movers  ·  RRT* ‖ SST",
+        ("occ", "paused"): "OCC  ·  paused  ·  RRT* ‖ SST",
+    }
+    if key in table:
+        return table[key]
+    return f"{scenario.upper()}  ·  {phase}"
+
+
+def build_compact_planner_sections(
+    planners: Sequence[tuple[str, tuple[int, int, int], dict[str, Any]]],
+) -> list[tuple[list[str], tuple[int, int, int]]]:
+    """Build short sidebar sections for planning / path-reveal phases.
+
+    Args:
+        planners: ``(name, color, metrics)`` rows.  Metrics may include
+            ``nodes``, ``steps``, ``planner_time``, ``planned_path_length``,
+            ``path_status``.
+
+    Returns:
+        Sidebar ``(lines, color)`` sections.
+    """
+
+    def _clock(seconds: float) -> str:
+        rounded = int(round(float(seconds)))
+        mins, secs = divmod(rounded, 60)
+        return f"{mins:02d}min{secs:02d}s"
+
+    sections: list[tuple[list[str], tuple[int, int, int]]] = []
+    for name, color, metrics in planners:
+        nodes = int(metrics.get("nodes", 0))
+        steps = int(metrics.get("steps", 0))
+        path_m = int(round(float(metrics.get("planned_path_length", 0.0))))
+        plan_t = _clock(float(metrics.get("planner_time", 0.0)))
+        status = str(metrics.get("path_status", "n/a"))
+        sections.append(
+            (
+                [
+                    name,
+                    f"  {nodes} nodes · {steps} steps",
+                    f"  plan {plan_t}",
+                    f"  path {path_m} m · {status}",
+                ],
+                color,
+            )
+        )
+    return sections
+
+
 def make_chrome_surface(
     layout: ScreenLayout,
     title: str,
     footer_hint: str,
     title_font: Any,
     hint_font: Any,
+    *,
+    method_colors: Sequence[tuple[int, int, int]] = (),
 ) -> Any:
     """Build a full-screen translucent chrome overlay surface.
 
-    Draws the header bar (top), footer bar (bottom), and sidebar background
-    (left).  The content area is left fully transparent.
+    Draws the header bar (left-aligned title + optional method accent
+    stripe), footer bar, and sidebar background.  The content area is left
+    fully transparent.  Colors come from ``ui.chrome_*`` in ``colors.yml``.
 
     Args:
         layout: Screen geometry descriptor.
-        title: Scene title rendered centered in the header bar.
+        title: Scene title rendered in the header bar.
         footer_hint: Short hint text rendered centered in the footer bar.
         title_font: Pygame font used to render *title*.
         hint_font: Pygame font used to render *footer_hint*.
+        method_colors: Optional method RGB colors drawn as a thin stripe
+            under the header (one segment each).
 
     Returns:
         A ``pygame.Surface`` with ``SRCALPHA`` pixel format, sized
@@ -119,53 +201,126 @@ def make_chrome_surface(
     """
     import pygame
 
+    from arco.config.palette import ui_rgb
+
     sw, sh = layout.sw, layout.sh
     sidebar_w = layout.sidebar_w
     header_h = layout.header_h
     footer_h = layout.footer_h
 
-    _C_DARK: tuple[int, int, int, int] = (14, 16, 26, 235)
-    _C_SIDEBAR: tuple[int, int, int, int] = (10, 12, 20, 235)
-    _C_BORDER: tuple[int, int, int, int] = (55, 70, 100, 255)
-    _C_TITLE: tuple[int, int, int] = (200, 210, 230)
-    _C_HINT: tuple[int, int, int] = (100, 115, 140)
+    bar = ui_rgb("chrome_bar")
+    side = ui_rgb("chrome_sidebar")
+    border = ui_rgb("chrome_border")
+    title_c = ui_rgb("chrome_title")
+    hint_c = ui_rgb("chrome_hint")
+
+    _C_DARK = (bar[0], bar[1], bar[2], 242)
+    _C_SIDEBAR = (side[0], side[1], side[2], 242)
+    _C_BORDER = (border[0], border[1], border[2], 255)
 
     surf = pygame.Surface((sw, sh), pygame.SRCALPHA)
     surf.fill((0, 0, 0, 0))
 
     # Header bar
     pygame.draw.rect(surf, _C_DARK, pygame.Rect(0, 0, sw, header_h))
-    pygame.draw.line(surf, _C_BORDER, (0, header_h - 1), (sw, header_h - 1))
     if title:
-        title_surf = title_font.render(title, True, _C_TITLE)
-        tx = (sw - title_surf.get_width()) // 2
-        ty = (header_h - title_surf.get_height()) // 2
-        surf.blit(title_surf, (tx, ty))
+        title_surf = title_font.render(title, True, title_c)
+        tx = 16
+        ty = (header_h - _METHOD_STRIPE_H - title_surf.get_height()) // 2
+        surf.blit(title_surf, (tx, max(2, ty)))
+
+    # Method accent stripe under the header (reads as a race identity bar).
+    stripe_y = header_h - _METHOD_STRIPE_H
+    if method_colors:
+        n = len(method_colors)
+        seg_w = max(1, sw // n)
+        for i, color in enumerate(method_colors):
+            x0 = i * seg_w
+            w = sw - x0 if i == n - 1 else seg_w
+            pygame.draw.rect(
+                surf,
+                (color[0], color[1], color[2], 255),
+                pygame.Rect(x0, stripe_y, w, _METHOD_STRIPE_H),
+            )
+    else:
+        pygame.draw.line(
+            surf, _C_BORDER, (0, header_h - 1), (sw, header_h - 1)
+        )
 
     # Footer bar
     fy = sh - footer_h
     pygame.draw.rect(surf, _C_DARK, pygame.Rect(0, fy, sw, footer_h))
     pygame.draw.line(surf, _C_BORDER, (0, fy), (sw, fy))
     if footer_hint:
-        hint_surf = hint_font.render(footer_hint, True, _C_HINT)
+        hint_surf = hint_font.render(footer_hint, True, hint_c)
         hx = (sw - hint_surf.get_width()) // 2
         hy = fy + (footer_h - hint_surf.get_height()) // 2
         surf.blit(hint_surf, (hx, hy))
 
-    # Sidebar background (between header and footer)
-    pygame.draw.rect(
-        surf,
-        _C_SIDEBAR,
-        pygame.Rect(0, header_h, sidebar_w, sh - header_h - footer_h),
-    )
-    pygame.draw.line(
-        surf,
-        _C_BORDER,
-        (sidebar_w - 1, header_h),
-        (sidebar_w - 1, sh - footer_h),
-    )
+    # Sidebar background (between header and footer) — skip when width is 0.
+    if sidebar_w > 0:
+        pygame.draw.rect(
+            surf,
+            _C_SIDEBAR,
+            pygame.Rect(0, header_h, sidebar_w, sh - header_h - footer_h),
+        )
+        pygame.draw.line(
+            surf,
+            _C_BORDER,
+            (sidebar_w - 1, header_h),
+            (sidebar_w - 1, sh - footer_h),
+        )
 
     return surf
+
+
+def paint_sidebar_panel(
+    target: Any,
+    layout: ScreenLayout,
+    font: Any,
+    sections: list[tuple[list[str], tuple[int, int, int]]],
+) -> None:
+    """Paint planner-info sections onto a pygame *target* surface.
+
+    Used by pure-pygame scenarios (OCC).  OpenGL scenarios should call
+    :func:`draw_sidebar_panel` instead.
+
+    Args:
+        target: Destination ``pygame.Surface`` (usually the display).
+        layout: Screen geometry descriptor.
+        font: Pygame monospace font.
+        sections: Ordered list of ``(lines, color)`` pairs.
+    """
+    if not sections or layout.sidebar_w <= 0:
+        return
+
+    import pygame
+
+    from arco.config.palette import ui_rgb
+
+    _C_SHADOW = ui_rgb("hud_shadow")
+    padding = 10
+    accent_w = 3
+    panel_w = layout.sidebar_w - 2 * padding
+    lh = font.get_linesize() + 2
+
+    y = layout.header_h + padding
+    for i, (lines, color) in enumerate(sections):
+        block_h = len(lines) * lh + 6
+        pygame.draw.rect(
+            target,
+            color,
+            pygame.Rect(padding, y, accent_w, max(block_h - 4, 8)),
+        )
+        text_x = padding + accent_w + 6
+        ty = y
+        for line in lines:
+            target.blit(
+                font.render(line, True, _C_SHADOW), (text_x + 1, ty + 1)
+            )
+            target.blit(font.render(line, True, color), (text_x, ty))
+            ty += lh
+        y = ty + (14 if i < len(sections) - 1 else 0)
 
 
 def draw_sidebar_panel(
@@ -175,11 +330,10 @@ def draw_sidebar_panel(
     sw: int,
     sh: int,
 ) -> None:
-    """Render planner-info sections as colored text in the sidebar.
+    """Render planner-info sections as colored text in the sidebar (OpenGL).
 
-    Each section is a ``(lines, color)`` pair. Sections are stacked
-    vertically with a blank spacer row between them. Text is rendered with
-    a subtle drop-shadow for readability against the dark sidebar.
+    Each section is a ``(lines, color)`` pair with a 3 px method accent bar
+    on the left.  Text uses a subtle drop-shadow for readability.
 
     Args:
         layout: Screen geometry descriptor.
@@ -188,7 +342,7 @@ def draw_sidebar_panel(
         sw: Screen width in pixels.
         sh: Screen height in pixels.
     """
-    if not sections:
+    if not sections or layout.sidebar_w <= 0:
         return
 
     import pygame
@@ -198,26 +352,34 @@ def draw_sidebar_panel(
 
     _C_SHADOW = ui_rgb("hud_shadow")
 
-    padding = 8
+    padding = 10
+    accent_w = 3
     panel_w = layout.sidebar_w - 2 * padding
     lh = font.get_linesize() + 2
 
-    entries: list[tuple[str, tuple[int, int, int] | None]] = []
-    for i, (lines, color) in enumerate(sections):
-        for line in lines:
-            entries.append((line, color))
+    # Measure total height.
+    total_h = padding
+    for i, (lines, _color) in enumerate(sections):
+        total_h += len(lines) * lh + 6
         if i < len(sections) - 1:
-            entries.append(("", None))
+            total_h += 14
+    total_h += padding
 
-    panel_h = len(entries) * lh + padding * 2
-    surf = pygame.Surface((panel_w, panel_h), pygame.SRCALPHA)
+    surf = pygame.Surface((panel_w, total_h), pygame.SRCALPHA)
     y = padding
-    for text, color in entries:
-        if not text or color is None:
-            y += lh
-            continue
-        surf.blit(font.render(text, True, _C_SHADOW), (1, y + 1))
-        surf.blit(font.render(text, True, color), (0, y))
-        y += lh
+    for i, (lines, color) in enumerate(sections):
+        block_h = len(lines) * lh + 6
+        pygame.draw.rect(
+            surf,
+            color,
+            pygame.Rect(0, y, accent_w, max(block_h - 4, 8)),
+        )
+        text_x = accent_w + 6
+        ty = y
+        for line in lines:
+            surf.blit(font.render(line, True, _C_SHADOW), (text_x + 1, ty + 1))
+            surf.blit(font.render(line, True, color), (text_x, ty))
+            ty += lh
+        y = ty + (14 if i < len(sections) - 1 else 0)
 
     renderer_gl.blit_overlay(surf, padding, layout.header_h + padding, sw, sh)

--- a/tests/control/mpc/test_tracking_loop.py
+++ b/tests/control/mpc/test_tracking_loop.py
@@ -90,7 +90,7 @@ def test_build_vehicle_mpc_sim_factory() -> None:
 
 
 def test_build_vehicle_mpc_sim_preserves_progress_first_weights() -> None:
-    """City YAML lag / deadzone must reach the race NMPC instance.
+    """City YAML lag / zero-deadzone must reach the race NMPC instance.
 
     ``build_vehicle_mpc_sim`` used to reconstruct PathFollowingMPCConfig
     without ``weight_lag`` / ``contour_deadzone``, silently disabling
@@ -114,12 +114,12 @@ def test_build_vehicle_mpc_sim_preserves_progress_first_weights() -> None:
         lag=4.0,
         control=0.5,
         obstacle=120.0,
-        contour_deadzone=2.5,
+        contour_deadzone=0.0,
     )
     _vehicle, loop = build_vehicle_mpc_sim(path, cfg, mpc_cfg)
     live = loop.tracker.config
     assert abs(live.cruise_speed - 12.0) < 1e-12
     assert abs(live.weight_lag - 4.0) < 1e-12
-    assert abs(live.contour_deadzone - 2.5) < 1e-12
+    assert abs(live.contour_deadzone) < 1e-12
     assert abs(live.weight_contour - 8.0) < 1e-12
     assert abs(live.weight_obstacle - 120.0) < 1e-12

--- a/tests/simulator/sim/test_city_race_style.py
+++ b/tests/simulator/sim/test_city_race_style.py
@@ -19,6 +19,8 @@ from arco.simulator.sim.city_race_style import (
     DEFAULT_CITY_HORIZON_STEP_COUNT,
     LOOKAHEAD_DISC_R,
     PAST_TRACE_WIDTH,
+    PLANNED_ROUTE_ALPHA,
+    PLANNED_ROUTE_WIDTH,
     PREDICTED_TRACE_WIDTH,
     VEH_HALF_L,
     VEH_HALF_W,
@@ -40,9 +42,12 @@ def test_city_race_vehicle_is_visible_rectangle() -> None:
 
 
 def test_city_race_traces_are_thicker_and_prediction_visible() -> None:
-    assert PAST_TRACE_WIDTH >= 2.0
-    assert PREDICTED_TRACE_WIDTH >= PAST_TRACE_WIDTH
+    # Executed past trail is the visual hero over a dim planned underlay.
+    assert PAST_TRACE_WIDTH >= 4.0
     assert PREDICTED_TRACE_WIDTH >= 3.0
+    assert PREDICTED_TRACE_WIDTH < PAST_TRACE_WIDTH
+    assert PLANNED_ROUTE_WIDTH < PAST_TRACE_WIDTH
+    assert 0.0 < PLANNED_ROUTE_ALPHA < 0.6
 
 
 def test_city_default_horizon_is_half_block() -> None:
@@ -130,7 +135,7 @@ def test_path_following_mpc_config_honors_weight_overrides() -> None:
                     "control": 0.5,
                     "progress": 4.0,
                     "lag": 4.0,
-                    "contour_deadzone": 2.5,
+                    "contour_deadzone": 0.0,
                 },
             },
         },
@@ -142,11 +147,11 @@ def test_path_following_mpc_config_honors_weight_overrides() -> None:
     assert abs(cfg.weight_control - 0.5) < 1e-12
     assert abs(cfg.weight_progress - 4.0) < 1e-12
     assert abs(cfg.weight_lag - 4.0) < 1e-12
-    assert abs(cfg.contour_deadzone - 2.5) < 1e-12
+    assert abs(cfg.contour_deadzone) < 1e-12
 
 
-def test_city_map_yaml_declares_lane_aware_progress_first() -> None:
-    """City YAML widens kinks inside the lane, not into walls."""
+def test_city_map_yaml_declares_progress_first_zero_deadzone() -> None:
+    """City YAML keeps lag/progress but no flat lateral cost band."""
     root = Path(__file__).resolve().parents[3]
     for name in ("city.yml", "city_mpc_preview.yml"):
         data = yaml.safe_load((root / "map" / name).read_text())
@@ -157,12 +162,11 @@ def test_city_map_yaml_declares_lane_aware_progress_first() -> None:
             < 1e-12
         )
         weights = data["simulator"]["mpc"]["weights"]
-        # Contour outside the band must dominate wall-seeking freedom.
+        # Contour must dominate wall-seeking freedom; lag still advances s.
         assert float(weights["contour"]) >= 6.0
         assert float(weights["heading"]) >= 3.0
         assert float(weights["lag"]) >= 2.0
         assert float(weights["lag"]) <= 6.0
-        # Free band ≪ road half-width (15 m) and planner clearance (8 m).
-        deadzone = float(weights["contour_deadzone"])
-        assert 1.0 <= deadzone <= 4.0
+        # Flat |e_lat| bands zero the lateral gradient → equal-cost chatter.
+        assert abs(float(weights["contour_deadzone"])) < 1e-12
         assert float(weights["obstacle"]) >= 100.0

--- a/tests/simulator/sim/test_city_race_view.py
+++ b/tests/simulator/sim/test_city_race_view.py
@@ -10,6 +10,15 @@ from arco.simulator.sim.city_race_view import (
 )
 
 
+def test_phase_chrome_title_matches_shared_helper() -> None:
+    from arco.simulator.sim.city_race_view import phase_chrome_title
+    from arco.simulator.sim.layout import scenario_phase_title
+
+    assert phase_chrome_title("racing") == scenario_phase_title(
+        "city", "racing"
+    )
+
+
 def test_pack_centroid_is_mean_of_positions() -> None:
     cx, cy = pack_centroid([(0.0, 0.0), (10.0, 20.0), (20.0, 10.0)])
     assert abs(cx - 10.0) < 1e-12

--- a/tests/simulator/sim/test_city_race_view.py
+++ b/tests/simulator/sim/test_city_race_view.py
@@ -1,0 +1,92 @@
+"""Tests for city race follow-cam framing and standings HUD."""
+
+from __future__ import annotations
+
+from arco.simulator.sim.city_race_view import (
+    RACE_VIEW_MIN_HALF_EXTENT,
+    build_race_standings,
+    pack_centroid,
+    race_view_bounds,
+)
+
+
+def test_pack_centroid_is_mean_of_positions() -> None:
+    cx, cy = pack_centroid([(0.0, 0.0), (10.0, 20.0), (20.0, 10.0)])
+    assert abs(cx - 10.0) < 1e-12
+    assert abs(cy - 10.0) < 1e-12
+
+
+def test_pack_centroid_empty_falls_back_to_origin() -> None:
+    assert pack_centroid([]) == (0.0, 0.0)
+
+
+def test_race_view_bounds_enforce_min_half_extent() -> None:
+    """A tight pack still gets a readable zoomed window, not a pinhead."""
+    x0, x1, y0, y1 = race_view_bounds(
+        100.0,
+        100.0,
+        [(98.0, 99.0), (102.0, 101.0)],
+        world_x_min=0.0,
+        world_x_max=600.0,
+        world_y_min=0.0,
+        world_y_max=600.0,
+    )
+    assert abs((x1 - x0) / 2.0 - RACE_VIEW_MIN_HALF_EXTENT) < 1e-9
+    assert abs((y1 - y0) / 2.0 - RACE_VIEW_MIN_HALF_EXTENT) < 1e-9
+    assert abs((x0 + x1) / 2.0 - 100.0) < 1e-9
+    assert abs((y0 + y1) / 2.0 - 100.0) < 1e-9
+
+
+def test_race_view_bounds_expand_to_fit_spread_pack() -> None:
+    x0, x1, y0, y1 = race_view_bounds(
+        200.0,
+        200.0,
+        [(100.0, 200.0), (300.0, 200.0)],
+        world_x_min=0.0,
+        world_x_max=600.0,
+        world_y_min=0.0,
+        world_y_max=600.0,
+        min_half_extent=80.0,
+        margin=40.0,
+    )
+    # span_x=200 → half = 100 + 40 = 140 > min 80
+    assert (x1 - x0) / 2.0 >= 140.0 - 1e-9
+    assert x0 >= 0.0 - 1e-9
+    assert x1 <= 600.0 + 1e-9
+
+
+def test_race_view_bounds_clamp_near_world_edge() -> None:
+    x0, x1, y0, y1 = race_view_bounds(
+        10.0,
+        10.0,
+        [(5.0, 5.0)],
+        world_x_min=0.0,
+        world_x_max=600.0,
+        world_y_min=0.0,
+        world_y_max=600.0,
+        min_half_extent=100.0,
+        margin=0.0,
+    )
+    assert x0 >= 0.0 - 1e-9
+    assert y0 >= 0.0 - 1e-9
+    assert x1 - x0 == 200.0
+    assert y1 - y0 == 200.0
+
+
+def test_build_race_standings_orders_finishers_then_active() -> None:
+    sections = build_race_standings(
+        [
+            ("RRT*", (70, 120, 200), None, 11.0),
+            ("SST", (70, 180, 100), 18.0, 0.0),
+            ("A*", (150, 80, 200), 15.5, 0.0),
+        ],
+        race_time=20.0,
+    )
+    assert len(sections) == 4  # header + 3 racers
+    header_lines, _ = sections[0]
+    assert header_lines[0] == "STANDINGS"
+    assert "1  A*" in sections[1][0][0]
+    assert "2  SST" in sections[2][0][0]
+    assert "3  RRT*" in sections[3][0][0]
+    assert any("GOAL 15.5" in line for line in sections[1][0])
+    assert any("11.0 m/s" in line for line in sections[3][0])

--- a/tests/simulator/sim/test_layout_chrome.py
+++ b/tests/simulator/sim/test_layout_chrome.py
@@ -1,0 +1,64 @@
+"""Tests for the shared arcosim presentation chrome."""
+
+from __future__ import annotations
+
+from arco.simulator.sim.layout import (
+    ScreenLayout,
+    build_compact_planner_sections,
+    scenario_phase_title,
+)
+
+
+def test_screen_layout_content_geometry() -> None:
+    layout = ScreenLayout(1280, 720, sidebar_w=280, header_h=44, footer_h=32)
+    assert layout.content_x == 280
+    assert layout.content_w == 1000
+    assert layout.content_h == 720 - 44 - 32
+    assert layout.content_y == 32
+
+
+def test_scenario_phase_title_city_and_arms() -> None:
+    assert scenario_phase_title("city", "background") == (
+        "City  ·  planning reveal"
+    )
+    assert scenario_phase_title("city", "racing") == "City  ·  race"
+    assert scenario_phase_title("ppp", "show") == "PPP  ·  path reveal"
+    assert scenario_phase_title("ppp", "race") == "PPP  ·  race"
+    assert scenario_phase_title("rrp", "done") == "RRP  ·  finished"
+    assert scenario_phase_title("occ", "running") == (
+        "OCC  ·  piano movers  ·  RRT* ‖ SST"
+    )
+
+
+def test_build_compact_planner_sections_keeps_method_colors() -> None:
+    sections = build_compact_planner_sections(
+        [
+            (
+                "RRT*",
+                (70, 120, 200),
+                {
+                    "steps": 100,
+                    "nodes": 80,
+                    "planner_time": 1.2,
+                    "planned_path_length": 42.0,
+                    "path_status": "ok",
+                },
+            ),
+            (
+                "SST",
+                (70, 180, 100),
+                {
+                    "steps": 200,
+                    "nodes": 90,
+                    "planner_time": 2.0,
+                    "planned_path_length": 50.0,
+                    "path_status": "ok",
+                },
+            ),
+        ]
+    )
+    assert len(sections) == 2
+    assert sections[0][0][0] == "RRT*"
+    assert sections[0][1] == (70, 120, 200)
+    assert any("80 nodes" in line for line in sections[0][0])
+    assert sections[1][1] == (70, 180, 100)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal
Refine how **all four** primary simulations are presented — not line-width tweaks — and keep city `contour_deadzone = 0` to kill flat-band chatter.

## Acceptance criteria
- Shared chrome language on **city / ppp / rrp / occ**: header phase title, method accent stripe, sidebar legend, footer hints
- Chrome colors from `ui.chrome_*` in `colors.yml` (no hardcoded HUD grays)
- PPP/RRP: leave floating status blob; use `ScreenLayout` content viewport + sidebar
- OCC: dual RRT*‖SST panels framed by the same chrome
- City: keep follow-cam + minimap + standings; compact planning sidebar
- `contour_deadzone: 0` in city YAML
- Format, unit tests, smoke for all four scenarios pass

## Why prior “polish” felt unchanged
v0.3.7 only nudged city trace widths. PPP/RRP stayed full-bleed with a gray floating HUD; OCC had no product chrome. This PR changes the **layout grammar** so release videos read as the same ARCO race shell.

## Commits
1. Zero city contour deadzone
2. City follow-cam / minimap / standings
3. Shared presentation chrome across all four scenarios

## Verification
- Format PASS
- Unit tests: 791 passed, 2 xfailed
- Smoke: city, ppp, rrp, occ PASS
- Frames: `/opt/cursor/artifacts/chrome_{city,ppp,rrp,occ}_frame.png`

![City chrome](https://cursor.com/artifacts/c/art-f15415ff-e46f-4979-b22b-faebd53aed8f)
![PPP chrome](https://cursor.com/artifacts/c/art-876069be-a6f3-40ef-9f70-b0de281b63fe)
![RRP chrome](https://cursor.com/artifacts/c/art-bc131b18-7844-45cb-9be1-bbe9714bdf68)
![OCC chrome](https://cursor.com/artifacts/c/art-ca321e2b-00e9-4fed-8423-56d111bbc7f3)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-535a9a43-65f7-4606-97e5-48b8d0ef55e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-535a9a43-65f7-4606-97e5-48b8d0ef55e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

