### PR TITLE
fix(control,simulator): classical MPCC for the city race + GTA2-style car sprites

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,15 +55,16 @@ jobs:
           esac
 
       - name: Generate video
-        # Duration 30 s with --fast-record ≈ the old 60 s clips that spent
-        # half the budget on cheap tree-reveal frames.  All frames are now
-        # race/tracking (MPC-heavy for city/ppp/rrp).
+        # 45 s at 30 fps × 0.1 s sim steps = 135 simulated seconds — enough
+        # for every racer (A* needs ~115 s on its windy grid route) to
+        # reach the goal on camera.  --fast-record skips tree-reveal
+        # pacing so all frames are race/tracking (MPC-heavy).
         run: |
           bash scripts/generate_videos.sh \
             --release \
             --only ${{ matrix.scenario }} \
             --out-dir /tmp/sim_videos \
-            --duration 30
+            --duration 45
 
       - name: Upload video artifact
         uses: actions/upload-artifact@v4

--- a/docs/ALGORITHMS.md
+++ b/docs/ALGORITHMS.md
@@ -168,11 +168,12 @@ Look-ahead search is O(n_path) per call.
 `src/arco/control/mpc/joint_space.py`
 
 CasADi + IPOPT NLPs solved each control step (optional `arco[mpc]` extra).
-Path-following MPC is an **NMPCC-style contouring controller**: path
-parameter \(s\), lateral / lag split, Dubins dynamics, soft obstacle
+Path-following MPC is a classical **MPCC contouring controller**: virtual
+progress speed \(v_s\) with a curve-limited cap, contouring / lag error
+split at \(p(s)\), linear progress reward, Dubins dynamics, soft obstacle
 barriers.  Full equations and naming vs classical MPCC:
 [control_mpcc.md](control_mpcc.md).  Post-plan tunable knobs (YAML weights,
-horizon, vehicle limits, κ floors):
+horizon, vehicle limits, κ shaping):
 [control_tracking_params.md](control_tracking_params.md).  Joint-space MPC
 tracks a carrot in configuration space with soft obstacle barriers.
 

--- a/docs/GUIDANCE.md
+++ b/docs/GUIDANCE.md
@@ -37,31 +37,31 @@ Feedback controllers that generate control inputs to track a reference trajector
   - Works well for car-like vehicles
 
 - **DubinsPathFollowingMPC** (`arco.control.mpc`): Receding-horizon
-  **contouring NMPC** (NMPCC-style).  Full mathematical description:
+  **contouring MPCC**.  Full mathematical description:
   [control_mpcc.md](control_mpcc.md).  Tunable knobs after planning
-  (horizon, weights, dynamics, κ floors): [control_tracking_params.md](control_tracking_params.md).
-  - Jointly optimizes contouring / lag / heading / speed / clearance
+  (horizon, weights, dynamics, κ shaping): [control_tracking_params.md](control_tracking_params.md).
+  - Classical MPCC structure: virtual progress speed `v_s` as a decision
+    variable (`ṡ = v_s ≥ 0`), contouring / lag error split at `p(s)`,
+    **linear** progress reward, `v_s` hard-capped by the curve-limited
+    cruise `min(v_cruise, ω_max/|κ(s)|)`
+  - Lag coupling is structural (`weight_lag > 0` enforced): it glues the
+    virtual progress to the vehicle, so no projection blending or
+    progress-monotonicity constraints are needed inside the NLP
   - CasADi + IPOPT backend via optional extra: `pip install arco[mpc]`
+  - Cubic B-spline reference interpolants and a straight runway extension
+    past the goal keep IPOPT convergent at polyline kinks and at the end
+    of the path
+  - Anti-stall: a parked warm start is replaced by a reference-rollout
+    initial guess so the solver can escape stopped equilibria at sharp
+    kinks (turn in place, then drive)
   - Soft directional obstacle barriers (not hard road tubes)
   - Paired with `MPCTrackingLoop`
-  - Enable in SE(2) races with `simulator.tracker: mpc`
-  - City race may override `simulator.mpc.horizon` (default **3.6 s**,
-    ~half a city block) and uses **progress-first contouring** with
-    **`contour_deadzone = 0`**: moderate lag/progress trade against a
-    strictly quadratic lateral cost so the NMPC may widen sharp A* kinks
-    **inside the navigable lane** while `s` advances.  Flat deadzone bands
-    zero the lateral gradient and invite equal-cost left/right chatter.
-    Planners ignore vehicle dynamics; the tracker treats the plan as a
-    topological lane guide, not free space into buildings.  Polyline
-    curvature uses consecutive heading turns + approach preview so
-    `v_curve = ω/|κ|` brakes before 90° kinks (κ floor keeps dense A*
-    stubs IPOPT-solvable).
-  - Contouring progress uses `ṡ = v max(cos e_ψ, 0)` so recovery arcs do
-    not reverse the path parameter (the limit-cycle behind city A* loops)
-  - Trajectory evolution: on straights the car stays near the reference;
-    on planner kinks it slows to a lane-feasible radius, trades contour
-    cost for progress, and keeps `s` increasing — instead of snap-turning,
-    orbiting, or cutting into walls
+  - Enable in SE(2) races with `simulator.tracker: mpc`; the model dt
+    must equal the control period (city: 50 × 0.1 s = 5.0 s preview)
+  - Trajectory evolution: on straights the car holds cruise near the
+    reference; before kinks the capped progress speed brakes it to a
+    lane-feasible corner speed, and `s` keeps increasing — no
+    snap-turning, orbiting, parked stalls, or wall cuts
 - **JointSpaceMPC** (`arco.control.mpc.joint_space`): N-DOF carrot-tracking NMPC
   - Drop-in for `JointSpaceTracker` (`reset` / `step` API)
   - Used by PPP / RRP when `tracker: mpc`

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@
 - [RRT*](planning_rrt.md)
 - [SST](planning_sst.md)
 - [Trajectory optimizer](planning_optimizer.md)
-- [Contouring NMPC (NMPCC-style)](control_mpcc.md)
+- [Contouring MPCC path following](control_mpcc.md)
 - [Post–path-planning tracking parameters](control_tracking_params.md)
 
 ## Tools and design

--- a/docs/VISUALIZATION.md
+++ b/docs/VISUALIZATION.md
@@ -80,31 +80,33 @@ Chrome colors live under `ui.chrome_*` in `src/arco/config/colors.yml`.
   sample budgets) while still writing `arcosim_city.mp4`.
 - Passes `--fast-record` so recordings skip tree-reveal pacing and spend the
   duration budget on the race / tracking phase.
-- Uses **30 s** clips (not 60 s): with fast-record every frame is
-  race/tracking; 30 s matches the race portion of the former 60 s videos
-  that spent ~half the time revealing trees.
+- Uses **45 s** clips: at 30 fps × 0.1 s sim steps that is 135 simulated
+  seconds — enough for every racer (A* needs ~115 s on its windy grid
+  route) to reach the goal on camera.
 - Caches pip and installs CasADi (`arco[mpc]`) only for scenarios whose YAML
   sets `tracker: mpc` (`city`, `ppp`, `rrp`).
 
 City race notes when `simulator.tracker: mpc`:
 
 - Scenario YAML may set `simulator.mpc.horizon.{step_count,dt}` (city default
-  is **72 × 0.05 s = 3.6 s**, ~43 m at the soft 12 m/s cruise ≈ half a block).
-  City uses **progress-first** contouring with **`contour_deadzone: 0`**
-  (`lag: 4`, `control: 0.5`, `obstacle: 120`) plus soft but lane-viable
-  turn limits (ω̇ 90 °/s²): planners ignore dynamics, so lag/progress trade
-  against contour to widen infeasible kinks **inside the road corridor**
-  while `s` advances (see `tools/mpc_progress_first_demo.py`).  A non-zero
-  deadzone flat-zones the lateral cost (zero gradient → equal-cost left/right
-  chatter / wobble); a prior 8 m band also ate planner clearance.  An
-  over-stiff retune (`control`/`obstacle` too high, ω̇ too low) understeered
-  then hunted — avoid that.  Full post-plan parameter inventory:
-  [control_tracking_params.md](control_tracking_params.md).
+  is **50 × 0.1 s = 5.0 s**; the model dt **must** equal the 0.1 s simulator
+  timestep — see [control_mpcc.md](control_mpcc.md)).  The tracker is a
+  classical **MPCC**: virtual progress speed capped by the curve-limited
+  cruise, structural lag coupling (`lag: 6`), linear progress reward
+  (`progress: 8`), strict quadratic contour (`contour: 10`,
+  `contour_deadzone: 0` — flat bands invite equal-cost chatter), light
+  heading alignment (`heading: 1`), soft obstacle barriers
+  (`obstacle: 120`).  Full post-plan parameter inventory:
+  [control_tracking_params.md](control_tracking_params.md); closed-loop
+  quality gate: `tools/city_tracking_report.py`.
 - The race renderer draws each racer's **MPC predicted XY polyline** (no tip
   disc) instead of a Pure-Pursuit carrot.
-- Race glyphs stay **oriented rectangles** (`8.0 × 3.6` m half-extents) over
-  the warm SDF road field: dim planned underlay (`2.0` px @ 0.35 α), bold
-  executed past trails (`4.5` px), and prediction polylines (`3.5` px).
+- Racers are **GTA2-style top-down car sprites**
+  (`arco.simulator.sim.car_sprite`, `8.0 × 3.6` m half-extents): pixel-art
+  body in each planner's color with dark glass, tires, head/taillights,
+  drawn as oriented textured quads over the warm SDF road field.  Dim
+  planned underlay (`2.0` px @ 0.35 α), bold executed past trails
+  (`4.5` px), and prediction polylines (`3.5` px) complete the look.
 - **Presentation (race phase):** follow-cam zooms to the pack (~200 m window,
   smoothed chase), a corner **minimap** keeps the full 600 m city, the sidebar
   switches to **standings** (place / gap / speed), and the header title flips

--- a/docs/control_mpcc.md
+++ b/docs/control_mpcc.md
@@ -1,15 +1,16 @@
-# Contouring NMPC (NMPCC-style path following)
+# Contouring NMPC (MPCC path following)
 
-ARCO’s SE(2) online tracker `DubinsPathFollowingMPC` is a **nonlinear model
-predictive contouring controller** (NMPCC-style): it augments the vehicle
-state with a path parameter \(s\), splits tracking into **contouring**
-(lateral) and **lag** (progress) costs, and solves a nonlinear program each
+ARCO's SE(2) online tracker `DubinsPathFollowingMPC` is a **nonlinear model
+predictive contouring controller** (MPCC): it augments the vehicle state
+with a path parameter \(s\) driven by its own **virtual progress speed**
+decision variable, splits the position error into **contouring** (lateral)
+and **lag** (longitudinal) components, and solves a nonlinear program each
 control step under Dubins / unicycle dynamics.
 
-It belongs to the same family as Model Predictive Contouring Control (MPCC),
-but it is **not** a drop-in of the classical racing MPCC formulation
-(free virtual speed \(\dot\theta\), hard corridor tubes).  This note documents
-**exactly what ARCO implements**.
+This is the classical Lam / Liniger MPCC structure.  This note documents
+**exactly what ARCO implements**, including the design decisions that fix
+the historical city-race failure modes (zigzag, junction orbits, parked
+stalls at sharp kinks).
 
 ## Key references (family)
 
@@ -31,6 +32,7 @@ Fully implemented in:
 | Arc-length path, \(\kappa\), projection | `src/arco/control/mpc/reference_path.py` |
 | Metrics loop | `src/arco/control/mpc/tracking_loop.py` |
 | City / sim factory | `src/arco/simulator/sim/tracking.py` |
+| Closed-loop city report | `tools/city_tracking_report.py` |
 | Demo (stiff vs lane-aware) | `tools/mpc_progress_first_demo.py` |
 
 Optional dependency: `pip install arco[mpc]` (CasADi + IPOPT).
@@ -48,11 +50,26 @@ s \in [0, L],
 \]
 
 with heading \(\psi_{\mathrm{ref}}(s)\) from segment tangents and an
-approximate curvature \(\kappa(s)\) used only for speed limiting.
+approximate curvature \(\kappa(s)\) used for progress-speed capping.
 
-### Curvature used for \(v_{\mathrm{curve}}\)
+Inside the NLP, the reference is resampled on a uniform arc-length grid
+(**2 m resolution**, 200–1500 samples) and looked up through **cubic
+B-spline CasADi interpolants**.  Piecewise-linear lookups have
+discontinuous gradients exactly at polyline kinks, which stalled IPOPT
+(`Maximum_Iterations_Exceeded`) right where tracking is hardest; smooth
+splines also round the polyline at the ~2 m sample scale, a desirable
+property for a vehicle-feasible target.
 
-At each interior vertex, the turn between consecutive outgoing headings is
+### Runway extension
+
+`set_reference` appends one prediction-horizon length of straight
+"runway" along the final tangent.  Without it, the progress bounds pinch
+\(S\) against the arc-length cap near the goal and the NLP fails on the
+last meters of the race.
+
+### Curvature estimate
+
+At each interior vertex, the turn between consecutive headings is
 
 \[
 \Delta\psi_i = \mathrm{wrap}\bigl(\psi_i - \psi_{i-1}\bigr),\qquad
@@ -61,14 +78,13 @@ At each interior vertex, the turn between consecutive outgoing headings is
 
 and for non-trivial turns \(\Delta s_i \leftarrow \max(\Delta s_i,\, s_{\mathrm{floor}})\)
 with \(s_{\mathrm{cap}} = 20\,\mathrm{m}\) and \(s_{\mathrm{floor}} = 8\,\mathrm{m}\),
-then \(\kappa_i = \Delta\psi_i / \Delta s_i\).  A backward max-preview
-(\(40\,\mathrm{m}\)) exposes upcoming corner \(\kappa\) on the approach, and
-\(|\kappa|\) is clipped to \(\kappa_{\max} = 0.35\,\mathrm{m}^{-1}\) so
-short A*/optimizer stubs cannot create Dirac \(\kappa\) that makes
-long-horizon IPOPT solves fail (city purple racer stuck at
-\(v_{\mathrm{cmd}}=0\)).  A skip-one finite difference
-\(\psi_{i+1}-\psi_{i-1}\) can report \(\kappa \approx 0\) on a \(90^\circ\)
-L-corner and disable braking — that is why consecutive headings are used.
+then \(\kappa_i = \Delta\psi_i / \Delta s_i\).  A **short** backward
+max-preview (12 m) keeps a corner \(\kappa\) visible just before the
+vertex; longer-range braking is planned by the receding horizon itself
+(a long preview double-counts the conservatism and drags cruise down on
+every straight).  \(|\kappa|\) is clipped to
+\(\kappa_{\max} = 0.35\,\mathrm{m}^{-1}\) so short A\*/optimizer stubs
+cannot create Dirac \(\kappa\).
 
 ---
 
@@ -80,9 +96,11 @@ Decision variables over horizon \(N\) with step \(\Delta t\):
 |--------|---------|
 | \(X_k = (p_x, p_y, \psi, v, \omega)_k\) | pose, speed, yaw rate |
 | \(U_k = (a, \dot\omega)_k\) | accel, yaw acceleration |
-| \(s_k\) | contouring path parameter (arc length) |
+| \(s_k\) | path parameter (arc length) |
+| \(v_{s,k}\) | **virtual progress speed** \(\dot s\) (decision variable) |
 
-Discrete Euler dynamics (matching `DubinsVehicle.step` saturation semantics):
+Discrete Euler dynamics (matching `DubinsVehicle.step` saturation
+semantics):
 
 \[
 \begin{aligned}
@@ -90,101 +108,113 @@ p_{x,k+1} &= p_{x,k} + v_k \cos\psi_k\,\Delta t,\\
 p_{y,k+1} &= p_{y,k} + v_k \sin\psi_k\,\Delta t,\\
 \psi_{k+1} &= \psi_k + \omega_k\,\Delta t,\\
 v_{k+1} &= v_k + a_k\,\Delta t,\\
-\omega_{k+1} &= \omega_k + \dot\omega_k\,\Delta t.
+\omega_{k+1} &= \omega_k + \dot\omega_k\,\Delta t,\\
+s_{k+1} &= s_k + v_{s,k}\,\Delta t.
 \end{aligned}
 \]
 
 Box constraints: \(v \in [v_{\min}, v_{\max}]\),
 \(|\omega| \le \omega_{\max}\), \(|a| \le a_{\max}\),
-\(|\dot\omega| \le \dot\omega_{\max}\), and \(s_k \in [0, L]\).
+\(|\dot\omega| \le \dot\omega_{\max}\), \(s_k \in [0, L]\), and
+\(v_{s,k} \ge 0\) (progress never reverses).
+
+### The model \(\Delta t\) must equal the control period
+
+The first predicted state \((v_1, \omega_1)\) is the command target the
+plant rate-limits toward for one **control period**.  If the model
+\(\Delta t\) is shorter than the control period (the historical city
+setup: 0.05 s model vs 0.1 s simulator step), the plant travels twice as
+far per tick as the plan's first step — a structural source of
+closed-loop zigzag.  City wiring: \(50 \times 0.1\,\mathrm{s} = 5.0\,\mathrm{s}\)
+of preview, longer than the 4.8 s full-stop braking time from cruise.
 
 ---
 
-## 3. Contouring errors
+## 3. Contouring / lag errors
 
 At predicted progress \(s_k\), interpolate
-\((x_{\mathrm{ref}}, y_{\mathrm{ref}}, \psi_{\mathrm{ref}}, \kappa)\).
-
-**Contouring (lateral) error** — signed, left positive:
+\((x_{\mathrm{ref}}, y_{\mathrm{ref}}, \psi_{\mathrm{ref}}, \kappa)\) and
+split the position error in the path frame:
 
 \[
-e_{c,k}
-=
+\begin{aligned}
+e_{c,k} &=
 -(p_{x,k}-x_{\mathrm{ref}})\sin\psi_{\mathrm{ref}}
-+(p_{y,k}-y_{\mathrm{ref}})\cos\psi_{\mathrm{ref}}.
++(p_{y,k}-y_{\mathrm{ref}})\cos\psi_{\mathrm{ref}}
+&&\text{(contouring, lateral)}\\
+e_{l,k} &=
+(p_{x,k}-x_{\mathrm{ref}})\cos\psi_{\mathrm{ref}}
++(p_{y,k}-y_{\mathrm{ref}})\sin\psi_{\mathrm{ref}}
+&&\text{(lag, longitudinal)}
+\end{aligned}
 \]
 
-**Heading error**:
+The **lag error is structural**: it is the only term coupling the virtual
+progress \(s\) to the vehicle, so `weight_lag` must be strictly positive
+(enforced at construction).  No projection heuristics or monotonicity
+constraints are needed *inside* the NLP.
 
-\[
-e_{\psi,k} = \psi_k - \psi_{\mathrm{ref}}(s_k).
-\]
+**Heading error** \(e_{\psi,k} = \psi_k - \psi_{\mathrm{ref}}(s_k)\) uses a
+smooth \(2\pi\)-periodic surrogate
+\(\ell_\psi(e_\psi) = \sin^2 e_\psi + (1-\cos e_\psi)^2\), kept at a
+**small weight**: heavy heading tracking on kinked planner references
+fights the contour/lag pair and produces steering chatter.
 
-Heading stage cost uses a smooth \(2\pi\)-periodic surrogate
-
-\[
-\ell_\psi(e_\psi) = \sin^2 e_\psi + (1-\cos e_\psi)^2.
-\]
-
-**Deadzone (optional free band).**  Only excess lateral error is penalized:
-
-\[
-e_{c,k}^{+}
-=
-\max\bigl(|e_{c,k}| - d_{\mathrm{dz}},\, 0\bigr),
-\qquad
-d_{\mathrm{dz}} = \texttt{contour\_deadzone}.
-\]
-
-With \(d_{\mathrm{dz}}=0\) this is classical quadratic contouring (city
-default).  A non-zero band creates a flat zero-cost / zero-gradient plateau
-where left and right commands share the same lateral cost and can chatter;
-prefer lag/progress tradeoffs for kink widening instead of a free band.
+**Deadzone (optional free band).**  With `contour_deadzone` \(> 0\), only
+the excess \(\max(|e_c| - d_{\mathrm{dz}}, 0)\) is penalized.  The default
+\(d_{\mathrm{dz}} = 0\) uses the plain smooth quadratic \(e_c^2\) (no
+`fabs` kink at zero).
 
 ---
 
-## 4. Path-parameter dynamics (progress law)
+## 4. Progress law: linear reward + curve-limited cap
 
-Contouring progress is **coupled** to the vehicle (not a free virtual speed):
+The progress incentive is **linear** (classical MPCC):
 
 \[
-s_{k+1}
-=
-s_k + v_k \,\max\bigl(\cos e_{\psi,k},\, 0\bigr)\,\Delta t.
+J_{\mathrm{prog}} = -\,w_p \sum_{k} v_{s,k}\,\Delta t
+\;=\; -\,w_p\,(s_N - s_0),
 \]
 
-When \(|e_\psi| > \pi/2\), progress stalls instead of reversing.  The older law
-\(\dot s = v\cos e_\psi\) drove \(s\) backward on recovery arcs and produced
-the city A\* junction limit cycle.
+with the virtual speed hard-capped by the curve-limited reference speed,
+written as two smooth inequalities (no `fmin`/`fabs` kinks in the
+constraint set):
+
+\[
+v_{s,k} \le v_{\mathrm{cruise}},
+\qquad
+v_{s,k}\,\sqrt{\kappa(s_k)^2 + \varepsilon} \le \omega_{\max}
+\;\;\Leftrightarrow\;\;
+v_{s,k} \le \frac{\omega_{\max}}{|\kappa(s_k)|}.
+\]
+
+**Why not quadratic speed-matching?**  The previous cost
+\(w_v (v_s - v_{\mathrm{ref}}(s_k))^2\) is a trap: at a sharp kink
+\(v_{\mathrm{ref}}(s)\) is small, so *parking at the kink* costs almost
+nothing while accelerating away looks expensive over the horizon — IPOPT
+then converges to a permanent full stop (the city A\* racer stall).  A
+linear reward makes advancement pay everywhere; corner braking stays
+feed-forward through the \(v_s\) cap, which the lag term transfers to the
+actual vehicle speed.
 
 **Measurement / seed.**  Each `step()` projects the measured pose onto the
-path in a local window around the current \(s\), then blends without rewind:
+path in a local window around the current \(s\) (a global nearest-point
+search can flip to another road corridor at junctions) and never rewinds:
+\(s \leftarrow \max(s, s_{\mathrm{proj}})\).  Recovery arcs catch up to
+\(s\) through the lag cost instead of resetting it.
 
-\[
-s \leftarrow \max\bigl(0.7\,s + 0.3\,s_{\mathrm{proj}},\, s\bigr).
-\]
-
----
-
-## 5. Speed reference
-
-Curve-limited cruise:
-
-\[
-v_{\mathrm{curve}}(s) = \frac{\omega_{\max}}{\max(|\kappa(s)|,\,10^{-3})},\qquad
-v_{\mathrm{ref}} = \mathrm{clip}\bigl(\min(v_{\mathrm{cruise}},\, v_{\mathrm{curve}}),\, v_{\min},\, v_{\max}\bigr).
-\]
-
-Optionally, path-ahead occupancy clearance further scales \(v_{\mathrm{cruise}}\)
-before the NLP (`_preview_cruise_speed`).
-
-Minimum turn radius at a chosen speed: \(R = v / \omega_{\max}\).  For lane
-feasibility at a sharp corner, \(v_{\mathrm{ref}}\) must drop until \(R\) fits
-inside the road corridor.
+**Warm start / anti-stall initialization.**  The solver warm-starts from
+the shifted previous solution while that solution keeps moving.  If the
+warm start advances less than \(\max(1, 0.1\, v_{\mathrm{cruise}} N \Delta t)\)
+meters over the horizon (a "parked" solution) while the path ahead allows
+motion, the initial guess is rebuilt as a **reference rollout**: poses on
+the path, speed accelerating toward the curve-limited cruise.  Seeding
+inside the moving basin is what lets IPOPT escape the parked local
+minimum at sharp kinks.
 
 ---
 
-## 6. Stage cost (what the NLP minimizes)
+## 5. Stage cost (what the NLP minimizes)
 
 For \(k = 0,\ldots,N-1\):
 
@@ -193,48 +223,41 @@ For \(k = 0,\ldots,N-1\):
 J &=
 \sum_{k=0}^{N-1}
 \Big[
-w_c\,(e_{c,k}^{+})^2
+w_c\,e_{c,k}^2
++ w_l\,e_{l,k}^2
 + w_\psi\,\ell_\psi(e_{\psi,k})
-+ w_v\,(v_{\mathrm{ref},k}-v_k)^2
-+ w_{\mathrm{lag}}\,\max(s_k^{\mathrm{tgt}}-s_k,\,0)^2
+- w_p\,v_{s,k}\,\Delta t
 + w_u\,(a_k^2+\dot\omega_k^2)
-+ w_{\mathrm{slack}}\,\sigma_k^2
 + J_{\mathrm{obs},k}
 \Big] \\
 &\quad
-+ w_T\bigl((e_{c,N}^{+})^2 + \ell_\psi(e_{\psi,N})\bigr)
-+ w_{\mathrm{lag}}\,\max(s_N^{\mathrm{tgt}}-s_N,\,0)^2
-+ w_{\mathrm{slack}}\,\sigma_N^2.
++ w_T\bigl(e_{c,N}^2 + \ell_\psi(e_{\psi,N})\bigr)
++ w_l\,e_{l,N}^2,
 \end{aligned}
 \]
 
-**Lag schedule** (behind-schedule only; being ahead is free):
-
-\[
-s_k^{\mathrm{tgt}} = \min\bigl(s_0 + v_{\mathrm{cruise}}\,k\,\Delta t,\, L\bigr).
-\]
+where \(e_{c}^2\) becomes \(\max(|e_c|-d_{\mathrm{dz}},0)^2\) when a
+deadzone is configured.
 
 Weights map to `PathFollowingMPCConfig` / YAML `simulator.mpc.weights`:
 
 | Weight | Config / YAML key |
 |--------|-------------------|
 | \(w_c\) | `weight_contour` / `contour` |
+| \(w_l\) | `weight_lag` / `lag` (must be \(> 0\)) |
 | \(w_\psi\) | `weight_heading` / `heading` |
-| \(w_v\) | `weight_progress` / `progress` |
-| \(w_{\mathrm{lag}}\) | `weight_lag` / `lag` |
+| \(w_p\) | `weight_progress` / `progress` |
 | \(w_u\) | `weight_control` / `control` |
 | \(w_{\mathrm{obs}}\) | `weight_obstacle` / `obstacle` |
+| \(w_T\) | `weight_terminal` / `terminal` |
 | \(d_{\mathrm{dz}}\) | `contour_deadzone` |
-
-Default global `mpc.yml` is **stiff** (\(d_{\mathrm{dz}}=0\), \(w_{\mathrm{lag}}=0\)).
-City overrides are **progress-first** (\(d_{\mathrm{dz}}=0\), moderate lag /
-contour / obstacle, light control): kink widening comes from the lag vs
-contour tradeoff, not from a flat lateral band.
 
 ### Soft obstacle barriers
 
 When an occupancy map is provided, nearest obstacle samples enter a
-directional penalty (stronger in the forward cone):
+directional penalty (stronger in the forward cone).  The cone factor is
+the **smooth** projection of the unit obstacle bearing onto the heading
+(no `atan2` kinks):
 
 \[
 J_{\mathrm{obs},k}
@@ -242,67 +265,75 @@ J_{\mathrm{obs},k}
 \sum_j
 w_{\mathrm{obs}}\,
 \Bigl(\max\bigl(\tfrac{c - d_{k,j}}{c},\,0\bigr)\Bigr)^{p}
-\bigl(0.2 + 0.8\max(\cos(\psi_k-\beta_{k,j}),\,0)\bigr),
+\Bigl(0.2 + 0.8\max\bigl(\tfrac{\cos\psi_k\,\Delta x_{k,j} + \sin\psi_k\,\Delta y_{k,j}}{d_{k,j}},\,0\bigr)\Bigr),
 \]
 
-with clearance \(c\), distance \(d_{k,j}\), bearing \(\beta_{k,j}\), and power
-\(p=\) `obstacle_barrier_power`.  This is **soft**, not a hard road tube.
+with clearance \(c\), obstacle offset \((\Delta x, \Delta y)\), distance
+\(d_{k,j}\), and power \(p =\) `obstacle_barrier_power`.  This is
+**soft**, not a hard road tube.  A clearance-based cruise preview
+(`_preview_cruise_speed`) additionally scales the cruise cap down before
+pinch points enter the horizon.
 
 ---
 
-## 7. Online problem
+## 6. Online problem
 
 At each control tick, with measured \((X_0, s_0)\):
 
 \[
 \begin{aligned}
-\min_{X,U,s,\sigma}\quad & J \\
+\min_{X,U,S,v_s}\quad & J \\
 \text{s.t.}\quad
 & \text{Dubins + progress dynamics above},\\
 & \text{box constraints on } v,\omega,a,\dot\omega,s,\\
+& v_{s,k} \in [0,\ \min(v_{\mathrm{cruise}},\ \omega_{\max}/|\kappa|)],\\
 & X_0,\, s_0 \text{ fixed from measurement}.
 \end{aligned}
 \]
 
-Solved with CasADi `Opti` + IPOPT.  The first input \((a_0,\dot\omega_0)\) is
-integrated to produce commands \((v_{\mathrm{cmd}}, \omega_{\mathrm{cmd}})\) for
-`DubinsVehicle`.
+Solved with CasADi `Opti` + IPOPT (acceptable-tolerance early exit
+enabled).  The first predicted state \((v_1, \omega_1)\) is the command
+target for `DubinsVehicle`.
 
 ---
 
-## 8. Naming: what this is / is not
+## 7. Naming: what this is / is not
 
 | Property | ARCO `DubinsPathFollowingMPC` | Classical racing MPCC |
 |----------|-------------------------------|------------------------|
 | Path parameter in the NLP | Yes (\(s\)) | Yes (\(\theta\)) |
 | Contour vs lag split | Yes | Yes |
 | Nonlinear dynamics in the NLP | Yes (NMPC) | Often yes (NMPCC) |
-| Progress law | \(\dot s = v\max(\cos e_\psi,0)\) | Free \(\dot\theta\) (virtual) |
+| Progress law | Free \(v_s\), linear reward, curve-limited cap | Free \(\dot\theta\), linear reward |
 | Spatial safety | Soft occupancy barriers | Often **hard corridor / tube** |
 | Reference | Planner polyline (may ignore dynamics) | Usually smooth centerline |
 
-So: **yes, this is an NMPCC-style contouring controller**; it is **not** yet
-CMPCC / MPCC++ (hard lane tubes + free virtual progress).  Those are natural
+So: this is a faithful MPCC with a curve-limited progress cap; it is
+**not** yet CMPCC / MPCC++ (hard lane tubes).  Those are natural
 extensions once the road corridor from the city mesh is exposed as
 constraints.
 
 ---
 
-## 9. City race contract
+## 8. City race contract
 
-Planners provide **topology** (which road corridor).  The tracker must keep a
-dynamically feasible trajectory in that corridor:
+Planners provide **topology** (which road corridor).  The tracker must keep
+a dynamically feasible trajectory in that corridor:
 
-1. Brake via \(\kappa \rightarrow v_{\mathrm{curve}}\) before sharp kinks.
-2. Allow small \(e_c\) inside \(d_{\mathrm{dz}}\) (widen the polyline corner).
-3. Penalize excess \(|e_c|\) and obstacles so the car does not spend the
-   planner’s clearance budget into buildings.
-4. Keep \(s\) non-decreasing under large heading error.
+1. Brake via the \(v_s \le \omega_{\max}/|\kappa|\) cap before sharp kinks
+   (previewed by the 5 s horizon).
+2. Keep \(|e_c|\) small with a strict quadratic (city keeps
+   \(d_{\mathrm{dz}} = 0\); flat bands chatter).
+3. Penalize obstacles so the car does not spend the planner's clearance
+   budget into buildings.
+4. Keep \(s\) non-decreasing and escape parked equilibria via the
+   reference-rollout re-seed.
 
-See `map/city.yml` (`simulator.mpc.*`) and `make_city_vehicle_config()` for
-the soft but lane-viable Dubins limits.  A full inventory of post–path-planning
-knobs (horizon, weights, actuator limits, κ floors, obstacle samples) is in
-[control_tracking_params.md](control_tracking_params.md).
+See `map/city.yml` (`simulator.mpc.*`) and `make_city_vehicle_config()`
+for the city Dubins limits.  A full inventory of post–path-planning knobs
+is in [control_tracking_params.md](control_tracking_params.md).
+Closed-loop quality (finish times, lateral error, footprint-collision
+gate) is measured headlessly by `tools/city_tracking_report.py`.
 
 ---
 
@@ -323,22 +354,22 @@ limits = DubinsVehicleLimits(
     max_turn_rate_dot=1.57,   # rad/s² (~90 deg/s²)
 )
 cfg = PathFollowingMPCConfig.create_from_config().with_weight_overrides(
-    contour=8.0,
-    heading=4.0,
-    control=0.5,
-    progress=4.0,
-    lag=4.0,
+    contour=10.0,
+    heading=1.0,
+    control=0.3,
+    progress=8.0,
+    lag=6.0,
     obstacle=120.0,
     contour_deadzone=0.0,
-)
+).with_horizon_overrides(step_count=50, dt=0.1)
 mpc = DubinsPathFollowingMPC(vehicle_limits=limits, config=cfg)
 mpc.set_reference([(0.0, 0.0), (40.0, 0.0), (40.0, 40.0)])
-result = mpc.step(pose=(0.0, 0.0, 0.0), speed=12.0, turn_rate=0.0)
+result = mpc.step(pose=(0.0, 0.0, 0.0), speed=12.0, turn_rate=0.0, dt=0.1)
 ```
 
 Enable in SE(2) races with `simulator.tracker: mpc` in the scenario YAML.
 
 ---
 
-*This document reflects the current contouring NMPC in ARCO.  If the NLP
+*This document reflects the current contouring MPCC in ARCO.  If the NLP
 cost or progress law changes, update this file in the same PR.*

--- a/docs/control_tracking_params.md
+++ b/docs/control_tracking_params.md
@@ -60,16 +60,19 @@ Global fallback: `config/mpc.yml` → `horizon`
 | `step_count` | — | Number of prediction steps \(N\) |
 | `dt` | s | Model step \(\Delta t\).  Horizon duration = \(N \cdot \Delta t\) |
 
-**City today:** \(72 \times 0.05\,\mathrm{s} = 3.6\,\mathrm{s}\) (~half a block at
-soft cruise).
+**City today:** \(50 \times 0.1\,\mathrm{s} = 5.0\,\mathrm{s}\) — longer than the
+4.8 s full-stop braking time from cruise (12 m/s at 2.5 m/s²).
 
 | Raise horizon | Lower horizon |
 |---------------|---------------|
 | Earlier braking / corner open; sees obstacles farther ahead | Faster IPOPT; less anticipation; late reactions at kinks |
 | Larger NLP → slower / more fragile solves | May cut corners the long horizon would have planned around |
 
-Tune **duration** (\(N\cdot\Delta t\)) first; keep \(\Delta t\) near the
-control period unless you have a reason to change discretization.
+**\(\Delta t\) must equal the control period** (the simulator timestep,
+0.1 s).  The first predicted state is the command target: with a model
+\(\Delta t\) shorter than the control period the plant travels further
+per tick than planned — the historical structural source of the city
+race zigzag.  Tune the duration via `step_count` only.
 
 ---
 
@@ -82,15 +85,14 @@ Globals: `config/mpc.yml` → `weights` (city overrides only listed keys)
 
 | YAML key | Config field | Role |
 |----------|--------------|------|
-| `contour` | `weight_contour` | Quadratic penalty on **excess** lateral error outside the deadzone |
+| `contour` | `weight_contour` | Quadratic penalty on lateral (contouring) error |
 | `contour_deadzone` | `contour_deadzone` | Free band \(\lvert e_{\mathrm{lat}}\rvert \le d_{\mathrm{dz}}\) (m); cost is zero inside. **City keeps this at 0** — flats zero the lateral gradient and invite equal-cost left/right chatter |
-| `heading` | `weight_heading` | Heading error vs path tangent |
-| `progress` | `weight_progress` | Track `v_ref` (cruise capped by curve speed) |
-| `lag` | `weight_lag` | Penalty for falling behind virtual progress \(s_0 + v_{\mathrm{cruise}} t\) |
+| `heading` | `weight_heading` | Heading alignment vs path tangent (keep **small**; tracking emerges from contour + lag) |
+| `progress` | `weight_progress` | **Linear** progress reward per meter of arc-length advancement (the virtual speed is hard-capped by the curve-limited cruise) |
+| `lag` | `weight_lag` | Lag error — **structural**: couples the virtual progress \(s\) to the vehicle.  Must be \(> 0\) (rejected otherwise) |
 | `control` | `weight_control` | Effort on \((a, \dot\omega)\) — smoothness vs agility |
 | `obstacle` | `weight_obstacle` | Soft directional obstacle barrier |
 | `terminal` | `weight_terminal` | Terminal contour / heading (usually from `mpc.yml`) |
-| `slack` | `weight_slack` | Soft-constraint slack (usually from `mpc.yml`) |
 
 Barrier shape (not a YAML weight, but couples to `obstacle`):
 
@@ -102,22 +104,24 @@ Barrier shape (not a YAML weight, but couples to `obstacle`):
 
 - **`control` high + `ω̇` low** → car cannot turn into planner kinks →
   understeer, then overshoot when contour finally wins → weave / wall hits.
-- **`contour` high + `contour_deadzone` tiny** → hunts the polyline; on
-  jagged A\* paths this looks like zigzag.
 - **`contour_deadzone` > 0** → flat zero-cost band; two commands with the
-  same lateral cost can alternate (wobble / chatter). Prefer `0` and let
-  lag/progress trade against contour for kink widening.
+  same lateral cost can alternate (wobble / chatter). Prefer `0`.
 - **`heading` high** on discontinuous planner yaw → left/right chasing.
-- **`lag` / `progress` high** → prefers advancing \(s\) and holding
-  `v_ref`; helps progress-first widening, but can pull through a soft
-  barrier if the reference itself cuts a corner.
+  Keep it a light alignment term (~1/10 of `contour`).
+- **`lag` low relative to `progress`** → the virtual point runs ahead of
+  the vehicle and drags it through corner cuts.  Keep `lag` comfortably
+  above zero; it is what glues \(s\) to the car.
+- **`progress` high** → advancement outbids tracking costs at kinks —
+  good for escaping parked equilibria, but past ~`contour`-scale values
+  the car starts trading lateral error for speed.
 - **`obstacle` high** strengthens soft barriers only; it is **not** a hard
   road tube.  Sparse point-cloud samples can still miss a face or fight
   contouring.
 
-City values are scenario YAML (`contour_deadzone: 0`, non-zero `lag`);
-global `mpc.yml` stays classic stiff (`contour_deadzone: 0`, `lag: 0`)
-for non-city demos.
+City values are scenario YAML (`map/city.yml`); global `mpc.yml` keeps
+smaller-scale defaults for the tools demos.  Both use `lag > 0` — a zero
+lag weight decouples the virtual progress and is rejected at
+construction.
 
 ---
 
@@ -156,7 +160,7 @@ inside the MPC — not the planner.
 | `_CURVATURE_DS_CAP_M` | m | Max arc length used to spread a heading turn into \(\kappa\) |
 | `_CURVATURE_DS_FLOOR_M` | m | Min spread for non-trivial turns (avoids Dirac \(\kappa\) on ~1 m A\* stubs → IPOPT failure / stuck \(v=0\)) |
 | `_CURVATURE_ABS_MAX` | 1/m | Hard cap on \(\lvert\kappa\rvert\) after preview |
-| `_CURVATURE_PREVIEW_DS_M` | m | Backward visibility of an upcoming corner \(\kappa\) so braking starts before the kink |
+| `_CURVATURE_PREVIEW_DS_M` | m | Backward visibility of an upcoming corner \(\kappa\) just before the vertex.  Kept **short** (12 m): the MPCC horizon plans braking itself, and a long preview drags cruise down between corners |
 
 These are code constants (not scenario YAML).  Changing them retunes
 braking aggressiveness and NLP solvability for dense polylines.
@@ -240,33 +244,37 @@ Change **one family at a time**; keep the other racers on the same pipeline.
 
 ---
 
-## City defaults vs aggressive stiffen (do not re-apply)
+## City defaults vs the retired formulations (do not re-apply)
 
-**Current city defaults** (progress-first, zero deadzone) are shared by
-blue / green / purple.  The right-hand column is the v0.3.5 over-stiff
-retune — kept only as an anti-pattern.
+**Current city defaults** (MPCC: linear progress reward, structural lag,
+zero deadzone) are shared by blue / green / purple.  The right column is
+the pre-v0.4 coupled-progress NMPC — kept only as an anti-pattern.
 
-| Knob | Current (progress-first) | Aggressive stiffen (avoid) |
-|------|--------------------------|----------------------------|
-| `contour` | 8 | 18 |
-| `heading` | 4 | 6 |
-| `control` | 0.5 | 4 |
-| `progress` | 4 | 3 |
-| `lag` | 4 | 2 |
-| `obstacle` | 120 | 280 |
-| `contour_deadzone` | **0 m** | 1.2 m (still a flat band) |
-| `CITY_MAX_TURN_RATE_DOT_DEG` | 90 | 55 |
-| Obstacle NLP samples | pose + path preview (5) | + forward/flank probes (9) |
-| Horizon | 72 × 0.05 s | same |
+| Knob | Current (MPCC) | Retired coupled-progress (avoid) |
+|------|----------------|----------------------------------|
+| `contour` | 10 | 8 |
+| `heading` | 1 | 4 |
+| `control` | 0.3 | 0.5 |
+| `progress` | 8 (linear reward / m) | 4 (quadratic `v_ref` matching) |
+| `lag` | 6 (lag error, structural) | 4 (behind-schedule penalty) |
+| `obstacle` | 120 | 120 |
+| `contour_deadzone` | **0 m** | 0 m |
+| Horizon | 50 × **0.1 s** (= control period) | 72 × 0.05 s (model ≠ plant step) |
 
-Raising `control` / obstacle / contour together while cutting \(\dot\omega\)
-often yields **solver “convergence” with poor tracking**: understeer into
-corners, then lateral hunting, then soft-barrier penetration.  A non-zero
-deadzone adds equal-cost chatter inside the flat band.  Nudge **one** knob
-at a time from the current column.
+Known failure modes of the retired column, all reproduced and fixed:
 
-Keep the **κ floor / preview** (`ReferencePath`): that fix is about NLP
-solvability on dense A\* stubs, not about stiffness.
+- **Model dt ≠ control period** → structural zigzag (the plant travels
+  2× the plan's first step every tick).
+- **`ṡ = v·max(cos e_ψ, 0)` coupled progress** → junction orbits and
+  circling; required projection blending / no-rewind hacks.
+- **Quadratic `(v_s − v_ref)²` progress** → parked local minimum at sharp
+  kinks (`v_ref` is tiny there, so stopping is nearly free).
+- **Piecewise-linear reference interpolants** → IPOPT
+  `Maximum_Iterations_Exceeded` exactly at kinks.
+
+Run `python tools/city_tracking_report.py` after any retune: it replays
+the full closed-loop race headlessly and gates on finish times and
+footprint collisions.
 
 ---
 

--- a/docs/control_tracking_params.md
+++ b/docs/control_tracking_params.md
@@ -289,6 +289,14 @@ footprint collisions.
 | Contouring NLP | `src/arco/control/mpc/path_following.py` |
 | Path κ / progress | `src/arco/control/mpc/reference_path.py` |
 | Math formulation | [control_mpcc.md](control_mpcc.md) |
+| PPP / RRP joint MPC horizon | `map/ppp.yml`, `map/rrp.yml` (`timestep` + `mpc.horizon.dt`) |
+| Joint-space NLP | `src/arco/control/mpc/joint_space.py` |
+
+**PPP / RRP:** these scenarios override the global 0.1 s simulator timestep
+with **0.05 s** (gantry / arm tuning).  The joint-space MPC horizon
+`dt` must match that control period — wired via
+`resolve_sim_timestep` and `joint_space_mpc_config_from_simulator` in
+`tracking.py`.  **OCC** has no MPC; it uses the global 0.1 s period.
 
 ---
 

--- a/map/city.yml
+++ b/map/city.yml
@@ -53,22 +53,18 @@ world:
 # follows that arbitrary reference (no replanning inside the tracker).
 simulator:
   tracker: mpc  # "pure_pursuit" (PP+APF) or "mpc" (CasADi path-following NMPC)
-  # Progress-first contouring with a strictly quadratic lateral cost.
-  # Global planners ignore vehicle dynamics; lag/progress still prefer
-  # advancing s over nailing sharp polyline kinks.  A non-zero
-  # contour_deadzone creates a flat |e_lat| ≤ d_dz band (zero cost / zero
-  # gradient) where left/right commands share the same cost and chatter —
-  # that flat zone is a common source of race wobble.  Keep d_dz = 0.
-  # Global mpc.yml is also deadzone=0 (and lag=0).
+  # MPCC tuning.  horizon.dt MUST equal the simulator timestep (0.1 s):
+  # the first predicted state is the command target, so a shorter model dt
+  # makes the plant overshoot the plan every tick (historical zigzag bug).
   mpc:
     horizon:
-      step_count: 72  # [] prediction steps
-      dt: 0.05  # [s] prediction model step
+      step_count: 50  # [] prediction steps (5.0 s preview at dt = 0.1)
+      dt: 0.1  # [s] prediction model step == simulator timestep
     weights:
-      contour: 8.0  # [] lateral contouring weight (quadratic in |e_lat|)
-      heading: 4.0  # [] heading tracking (plan has no yaw continuity)
-      control: 0.5  # [] control effort — prefer smooth ω
-      progress: 4.0  # [] track v_ref (incl. curve-limited corner speed)
-      lag: 4.0  # [] behind-schedule progress (do not overpower braking)
+      contour: 10.0  # [] lateral contouring weight (quadratic in |e_lat|)
+      heading: 1.0  # [] heading alignment (small; emerges from contour+lag)
+      control: 0.3  # [] control effort — prefer smooth a / ω̇
+      progress: 8.0  # [] linear progress reward (v_s is capped by v_ref)
+      lag: 6.0  # [] lag error — glues virtual progress s to the vehicle
       obstacle: 120.0  # [] keep the topological lane clear of buildings
       contour_deadzone: 0.0  # [m] no flat lateral band (avoids equal-cost chatter)

--- a/map/city_mpc_preview.yml
+++ b/map/city_mpc_preview.yml
@@ -28,16 +28,16 @@ world:
   seed: 42
 simulator:
   tracker: mpc
-  # Match city.yml: half-block horizon + progress-first, deadzone=0.
+  # Match city.yml: MPCC with horizon dt == simulator timestep.
   mpc:
     horizon:
-      step_count: 72
-      dt: 0.05
+      step_count: 50
+      dt: 0.1
     weights:
-      contour: 8.0
-      heading: 4.0
-      control: 0.5
-      progress: 4.0
-      lag: 4.0
+      contour: 10.0
+      heading: 1.0
+      control: 0.3
+      progress: 8.0
+      lag: 6.0
       obstacle: 120.0
       contour_deadzone: 0.0

--- a/map/occ.yml
+++ b/map/occ.yml
@@ -69,5 +69,5 @@ control:
   k_rep: 5.0      # [N/m²] APF repulsion stiffness; d0 = 4 × standoff
 
 simulator:
-  dt: 0.1         # [s] simulation time step
+  timestep: 0.1         # [s] simulation time step (matches global simulator.yml)
   race_speed: 0.1 # [m/s] speed for path following

--- a/map/ppp.yml
+++ b/map/ppp.yml
@@ -56,8 +56,16 @@ planner:
 
 # Speed at which the carrot target advances along the planned path (m/s).
 simulator:
+  # Finer control period than the global simulator.yml (0.1 s): gantry
+  # dynamics and carrot leash were tuned at dt = 0.05 s.  MPC horizon dt
+  # MUST equal this timestep (same rule as city path-following MPCC).
+  timestep: 0.05  # [s] simulation / control period
   # Online tracker: "pure_pursuit" (P+APF) or "mpc" (joint-space CasADi NMPC).
   tracker: mpc
+  mpc:
+    horizon:
+      step_count: 12  # [] prediction steps (0.6 s preview at dt = 0.05)
+      dt: 0.05  # [s] prediction model step == simulator timestep
   race_speed: 2.0  # [m/s] speed at which the carrot target advances along the planned path
 
 # Maximum speed per prismatic joint axis (m/s).

--- a/map/rrp.yml
+++ b/map/rrp.yml
@@ -81,6 +81,13 @@ planner:
 # Simulator parameters
 # ---------------------------------------------------------------------------
 simulator:
+  # Finer control period than the global simulator.yml (0.1 s); MPC horizon
+  # dt MUST equal this timestep (same rule as city path-following MPCC).
+  timestep: 0.05  # [s] simulation / control period
   # Online tracker: "pure_pursuit" (P+APF) or "mpc" (joint-space CasADi NMPC).
   tracker: mpc
+  mpc:
+    horizon:
+      step_count: 12  # [] prediction steps (0.6 s preview at dt = 0.05)
+      dt: 0.05  # [s] prediction model step == simulator timestep
   race_speed: 0.6  # [m/s] speed for end-effector path following

--- a/src/arco/config/mpc.yml
+++ b/src/arco/config/mpc.yml
@@ -3,7 +3,7 @@
 
 horizon:
   step_count: 20
-  dt: 0.05
+  dt: 0.1  # default path-following model step; must match control period
 
 weights:
   # Lateral contouring error (quadratic outside contour_deadzone).

--- a/src/arco/config/mpc.yml
+++ b/src/arco/config/mpc.yml
@@ -1,4 +1,4 @@
-# Path-following MPC defaults for DubinsPathFollowingMPC.
+# Path-following MPCC defaults for DubinsPathFollowingMPC.
 # Non-SI unit suffixes are not used; all quantities are SI.
 
 horizon:
@@ -6,23 +6,27 @@ horizon:
   dt: 0.05
 
 weights:
+  # Lateral contouring error (quadratic outside contour_deadzone).
   contour: 10.0
-  heading: 5.0
+  # Heading alignment (small: heading emerges from contour + lag).
+  heading: 2.0
+  # Linear progress reward per meter of advancement (the virtual progress
+  # speed is hard-capped by the curve-limited reference speed).
   progress: 1.0
-  # lag / contour_deadzone default to 0 → classic stiff path hugging.
-  # City race overrides these to prefer advancing s over minimizing e_lat.
-  lag: 0.0
+  # Lag error — structural in MPCC: couples the virtual progress s to the
+  # vehicle position.  Must be strictly positive.
+  lag: 4.0
+  # contour_deadzone defaults to 0 → classic stiff path hugging.
   contour_deadzone: 0.0
   control: 0.1
   obstacle: 50.0
   terminal: 20.0
-  slack: 1.0
 
 obstacle_barrier:
   power: 4.0
 
 solver:
-  max_iter_count: 50
+  max_iter_count: 80
 
 # Joint-space carrot-tracking MPC (PPP / RRP / N-DOF).
 joint_space:
@@ -38,4 +42,3 @@ joint_space:
     power: 4.0
   solver:
     max_iter_count: 40
-

--- a/src/arco/control/mpc/joint_space.py
+++ b/src/arco/control/mpc/joint_space.py
@@ -8,7 +8,7 @@ APF repulsion with a short-horizon CasADi/IPOPT solve.
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
@@ -84,6 +84,32 @@ class JointSpaceMPCConfig:
             weight_obstacle=float(weights.get("obstacle", 60.0)),
             obstacle_barrier_power=float(barrier.get("power", 4.0)),
             max_solver_iter_count=int(solver.get("max_iter_count", 40)),
+        )
+
+    def with_horizon_overrides(
+        self,
+        *,
+        step_count: int | None = None,
+        dt: float | None = None,
+    ) -> JointSpaceMPCConfig:
+        """Return a copy with optional horizon overrides applied.
+
+        Args:
+            step_count: Optional new prediction horizon length (steps).
+            dt: Optional new discretization step (s).
+
+        Returns:
+            A new :class:`JointSpaceMPCConfig` with the requested horizon
+            fields replaced; other fields are unchanged.
+        """
+        return replace(
+            self,
+            horizon_step_count=(
+                self.horizon_step_count
+                if step_count is None
+                else int(step_count)
+            ),
+            dt=self.dt if dt is None else float(dt),
         )
 
 
@@ -178,6 +204,13 @@ class JointSpaceMPC:
             raise ValueError(
                 f"target_q length {target.shape[0]} != DOF {self._dof}."
             )
+        if abs(dt - self.config.dt) > 1e-9:
+            raise ValueError(
+                f"JointSpaceMPC step dt ({dt}) must equal config.dt "
+                f"({self.config.dt}); mismatch causes the same closed-loop "
+                "zigzag as path-following MPC model dt ≠ control period."
+            )
+
         if not np.all(np.isfinite(self.q)) or not np.all(np.isfinite(target)):
             return self._safe_decelerate(dt)
 

--- a/src/arco/control/mpc/path_following.py
+++ b/src/arco/control/mpc/path_following.py
@@ -1,10 +1,10 @@
-"""DubinsPathFollowingMPC: SE(2) unicycle contouring NMPC."""
+"""DubinsPathFollowingMPC: SE(2) unicycle contouring NMPC (MPCC)."""
 
 from __future__ import annotations
 
 import math
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 import numpy as np
@@ -76,24 +76,35 @@ class DubinsVehicleLimits:
 
 @dataclass
 class PathFollowingMPCConfig:
-    """Tunable weights and horizon for Dubins path-following MPC.
+    """Tunable weights and horizon for Dubins path-following MPCC.
+
+    The controller is a Model Predictive Contouring Controller: the path
+    parameter ``s`` advances with its own *virtual progress speed*
+    decision variable, and the position error is split into a lateral
+    **contouring** error and a longitudinal **lag** error, both evaluated
+    at the reference point ``p(s_k)``.
 
     Attributes:
         horizon_step_count: Prediction horizon length (steps).
-        dt: Discretization step for the prediction model (s).
+        dt: Discretization step for the prediction model (s).  Must match
+            the closed-loop control period for the first predicted state
+            to be a valid command target.
         cruise_speed: Nominal progress speed on straights (m/s).
         weight_contour: Lateral (contouring) error weight applied outside
             :attr:`contour_deadzone`.
-        weight_heading: Heading error weight.
-        weight_progress: Speed-tracking weight toward cruise / curve limit.
-        weight_lag: Penalty on falling behind virtual arc-length progress
-            ``s0 + v_cruise · t``.  Prefer advancing ``s`` over hugging the
-            path when non-zero.
+        weight_heading: Heading alignment weight (smooth 2π-periodic cost).
+        weight_progress: Linear progress reward per meter of arc-length
+            advancement.  The virtual speed is hard-capped by the
+            curve-limited reference speed, so this only decides how
+            strongly advancement pays against tracking costs.
+        weight_lag: Lag-error weight.  Structural in MPCC: it couples the
+            virtual progress ``s`` to the vehicle position.  Larger values
+            keep ``p(s)`` glued to the vehicle; ``0`` decouples ``s`` and
+            is rejected at construction time.
         weight_control: Control-effort weight on ``(a, ω̇)``.
         weight_obstacle: Soft obstacle-barrier weight.
         obstacle_barrier_power: Barrier exponent.
         weight_terminal: Terminal contouring / heading weight.
-        weight_slack: Soft constraint slack weight.
         contour_deadzone: Lateral free band (m).  Contouring cost is zero
             for ``|e_lat| ≤ contour_deadzone`` and quadratic on the excess.
         max_solver_iter_count: IPOPT iteration budget.
@@ -103,16 +114,15 @@ class PathFollowingMPCConfig:
     dt: float = 0.05
     cruise_speed: float = 0.36
     weight_contour: float = 10.0
-    weight_heading: float = 5.0
+    weight_heading: float = 2.0
     weight_progress: float = 1.0
-    weight_lag: float = 0.0
+    weight_lag: float = 4.0
     weight_control: float = 0.1
     weight_obstacle: float = 50.0
     obstacle_barrier_power: float = 4.0
     weight_terminal: float = 20.0
-    weight_slack: float = 1.0
     contour_deadzone: float = 0.0
-    max_solver_iter_count: int = 50
+    max_solver_iter_count: int = 80
 
     @staticmethod
     def create_from_config(
@@ -141,16 +151,15 @@ class PathFollowingMPCConfig:
             dt=float(horizon.get("dt", 0.05)),
             cruise_speed=cruise,
             weight_contour=float(weights.get("contour", 10.0)),
-            weight_heading=float(weights.get("heading", 5.0)),
+            weight_heading=float(weights.get("heading", 2.0)),
             weight_progress=float(weights.get("progress", 1.0)),
-            weight_lag=float(weights.get("lag", 0.0)),
+            weight_lag=float(weights.get("lag", 4.0)),
             weight_control=float(weights.get("control", 0.1)),
             weight_obstacle=float(weights.get("obstacle", 50.0)),
             weight_terminal=float(weights.get("terminal", 20.0)),
-            weight_slack=float(weights.get("slack", 1.0)),
             contour_deadzone=float(weights.get("contour_deadzone", 0.0)),
             obstacle_barrier_power=float(barrier.get("power", 4.0)),
-            max_solver_iter_count=int(solver.get("max_iter_count", 50)),
+            max_solver_iter_count=int(solver.get("max_iter_count", 80)),
         )
 
     def with_horizon_overrides(
@@ -169,25 +178,14 @@ class PathFollowingMPCConfig:
             A new :class:`PathFollowingMPCConfig` with the requested
             horizon fields replaced; other fields are unchanged.
         """
-        return PathFollowingMPCConfig(
+        return replace(
+            self,
             horizon_step_count=(
                 int(step_count)
                 if step_count is not None
                 else self.horizon_step_count
             ),
             dt=float(dt) if dt is not None else self.dt,
-            cruise_speed=self.cruise_speed,
-            weight_contour=self.weight_contour,
-            weight_heading=self.weight_heading,
-            weight_progress=self.weight_progress,
-            weight_lag=self.weight_lag,
-            weight_control=self.weight_control,
-            weight_obstacle=self.weight_obstacle,
-            obstacle_barrier_power=self.obstacle_barrier_power,
-            weight_terminal=self.weight_terminal,
-            weight_slack=self.weight_slack,
-            contour_deadzone=self.contour_deadzone,
-            max_solver_iter_count=self.max_solver_iter_count,
         )
 
     def with_weight_overrides(
@@ -200,30 +198,26 @@ class PathFollowingMPCConfig:
         control: float | None = None,
         obstacle: float | None = None,
         terminal: float | None = None,
-        slack: float | None = None,
         contour_deadzone: float | None = None,
     ) -> PathFollowingMPCConfig:
         """Return a copy with optional cost-weight overrides applied.
 
         Args:
             contour: Optional lateral / contouring weight.
-            heading: Optional heading-error weight.
-            progress: Optional speed-tracking weight.
-            lag: Optional behind-schedule arc-length lag weight.
+            heading: Optional heading-alignment weight.
+            progress: Optional virtual-progress speed-tracking weight.
+            lag: Optional lag-error weight (must stay positive).
             control: Optional control-effort weight.
             obstacle: Optional obstacle-barrier weight.
             terminal: Optional terminal cost weight.
-            slack: Optional slack penalty weight.
             contour_deadzone: Optional free lateral band (m).
 
         Returns:
             A new :class:`PathFollowingMPCConfig` with the requested
             weight fields replaced; other fields are unchanged.
         """
-        return PathFollowingMPCConfig(
-            horizon_step_count=self.horizon_step_count,
-            dt=self.dt,
-            cruise_speed=self.cruise_speed,
+        return replace(
+            self,
             weight_contour=(
                 float(contour) if contour is not None else self.weight_contour
             ),
@@ -244,38 +238,44 @@ class PathFollowingMPCConfig:
                 if obstacle is not None
                 else self.weight_obstacle
             ),
-            obstacle_barrier_power=self.obstacle_barrier_power,
             weight_terminal=(
                 float(terminal)
                 if terminal is not None
                 else self.weight_terminal
-            ),
-            weight_slack=(
-                float(slack) if slack is not None else self.weight_slack
             ),
             contour_deadzone=(
                 float(contour_deadzone)
                 if contour_deadzone is not None
                 else self.contour_deadzone
             ),
-            max_solver_iter_count=self.max_solver_iter_count,
         )
 
 
 class DubinsPathFollowingMPC(MPCTracker):
-    """Receding-horizon contouring NMPC (NMPCC-style) for Dubins vehicles.
+    """Receding-horizon contouring NMPC (MPCC) for Dubins vehicles.
 
-    Jointly optimizes lateral (contouring) error, lag / progress, heading,
-    speed, control effort, and directional obstacle clearance under
-    discrete-Euler unicycle dynamics matching
-    :meth:`~arco.guidance.vehicle.DubinsVehicle.step` saturation semantics.
+    Follows the Lam / Liniger MPCC structure: the path parameter ``s`` is
+    advanced by a bounded **virtual progress speed** decision variable,
+    and the position error at ``p(s_k)`` is split into a lateral
+    contouring error and a longitudinal lag error.  The lag term couples
+    the virtual progress to the vehicle, so no projection heuristics or
+    monotonicity constraints are needed inside the NLP.
 
     Mathematical formulation, symbols, and differences from classical
     racing MPCC are documented in ``docs/control_mpcc.md``.
+
+    Raises:
+        ValueError: If ``config.weight_lag`` is not strictly positive —
+            with a zero lag weight the virtual progress decouples from
+            the vehicle and the contouring errors lose meaning.
     """
 
     _OBSTACLE_SAMPLE_COUNT = 5
-    _PATH_INTERP_COUNT = 200
+    # Reference resampling resolution (m) and sample-count bounds.  The
+    # previous fixed 200-sample grid smeared corners on ~900 m city paths.
+    _PATH_INTERP_RESOLUTION_M = 2.0
+    _PATH_INTERP_MIN_COUNT = 200
+    _PATH_INTERP_MAX_COUNT = 1500
 
     def __init__(
         self,
@@ -284,7 +284,7 @@ class DubinsPathFollowingMPC(MPCTracker):
         config: PathFollowingMPCConfig,
         occupancy: Occupancy | None = None,
     ) -> None:
-        """Initialize the Dubins path-following MPC.
+        """Initialize the Dubins path-following MPCC.
 
         Args:
             vehicle_limits: Speed / turn-rate / acceleration limits.
@@ -293,9 +293,16 @@ class DubinsPathFollowingMPC(MPCTracker):
 
         Raises:
             ImportError: If the optional CasADi dependency is missing.
+            ValueError: If ``config.weight_lag <= 0``.
         """
         # Eager dependency check so missing CasADi fails at construction.
         self._ca = _require_casadi()
+        if config.weight_lag <= 0.0:
+            raise ValueError(
+                "PathFollowingMPCConfig.weight_lag must be > 0: the lag "
+                "error is what couples the virtual progress s to the "
+                "vehicle in the MPCC formulation."
+            )
         self.vehicle_limits = vehicle_limits
         self.config = config
         self._occupancy = occupancy
@@ -304,6 +311,7 @@ class DubinsPathFollowingMPC(MPCTracker):
         self._warm_x: np.ndarray | None = None
         self._warm_u: np.ndarray | None = None
         self._warm_s: np.ndarray | None = None
+        self._warm_vs: np.ndarray | None = None
         self._last_speed_cmd = config.cruise_speed
         self._last_turn_rate_cmd = 0.0
         self._nlp: dict[str, Any] | None = None
@@ -317,21 +325,55 @@ class DubinsPathFollowingMPC(MPCTracker):
     def set_reference(self, waypoints: Sequence[tuple[float, float]]) -> None:
         """Set or replace the reference path.
 
+        The polyline is extended by one prediction-horizon length of
+        straight "runway" along the final tangent so the NLP feasible set
+        has no hard corner at the goal (progress bounds pinching ``S``
+        against its cap caused end-of-path solver failures).
+
         Args:
             waypoints: Ordered ``(x, y)`` waypoints in world frame.
         """
-        self._reference = ReferencePath(waypoints)
+        pts = [(float(x), float(y)) for x, y in waypoints]
+        if len(pts) >= 2:
+            pad = max(
+                2.0,
+                self.config.cruise_speed
+                * self.config.dt
+                * self.config.horizon_step_count,
+            )
+            dx = pts[-1][0] - pts[-2][0]
+            dy = pts[-1][1] - pts[-2][1]
+            norm = math.hypot(dx, dy)
+            if norm > 1e-9:
+                pts.append(
+                    (
+                        pts[-1][0] + pad * dx / norm,
+                        pts[-1][1] + pad * dy / norm,
+                    )
+                )
+        self._reference = ReferencePath(pts)
+        sample_count = int(
+            np.clip(
+                math.ceil(
+                    self._reference.total_length
+                    / self._PATH_INTERP_RESOLUTION_M
+                ),
+                self._PATH_INTERP_MIN_COUNT,
+                self._PATH_INTERP_MAX_COUNT,
+            )
+        )
         (
             self._path_s,
             self._path_x,
             self._path_y,
             self._path_heading,
             self._path_kappa,
-        ) = self._reference.sample(self._PATH_INTERP_COUNT)
+        ) = self._reference.sample(sample_count)
         self._progress = 0.0
         self._warm_x = None
         self._warm_u = None
         self._warm_s = None
+        self._warm_vs = None
         self._nlp = None
 
     def step(
@@ -349,7 +391,8 @@ class DubinsPathFollowingMPC(MPCTracker):
             speed: Current forward speed (m/s).
             turn_rate: Current turn rate (rad/s).
             dt: Control period until the next call (s).  The internal
-                prediction model uses :attr:`PathFollowingMPCConfig.dt`.
+                prediction model uses :attr:`PathFollowingMPCConfig.dt`;
+                configure them equal for consistent closed-loop tracking.
 
         Returns:
             Structured command and solver diagnostics.
@@ -374,10 +417,10 @@ class DubinsPathFollowingMPC(MPCTracker):
             )
 
         # Local projection around the current contouring progress.  A global
-        # nearest-point search can jump backward by a full city-block when the
-        # vehicle cuts a sharp A* corner and sits geometrically closer to an
-        # earlier approach lane — that regression is what starts permanent
-        # circling in the city race.
+        # nearest-point search can jump by a full city block when two road
+        # corridors of the route pass near each other.  Progress never
+        # rewinds: recovery arcs must catch up to s, not reset it (the lag
+        # cost pulls the vehicle forward toward p(s)).
         horizon_m = (
             self.config.cruise_speed
             * self.config.dt
@@ -389,13 +432,12 @@ class DubinsPathFollowingMPC(MPCTracker):
             s_hint=self._progress,
             window=project_window,
         )
-        # Blend toward the geometric projection, but never rewind contouring
-        # progress.  Driving past a sharp corner with large e_ψ used to pull
-        # s backward via this filter and start the city A* junction orbit.
-        blended = 0.7 * self._progress + 0.3 * s_proj
-        self._progress = float(max(blended, self._progress))
         self._progress = float(
-            np.clip(self._progress, 0.0, self._reference.total_length)
+            np.clip(
+                max(s_proj, self._progress),
+                0.0,
+                self._reference.total_length,
+            )
         )
 
         obstacles = self._collect_obstacle_samples(pose)
@@ -454,6 +496,7 @@ class DubinsPathFollowingMPC(MPCTracker):
         self._warm_x = sol["X"]
         self._warm_u = sol["U"]
         self._warm_s = sol["S"]
+        self._warm_vs = sol["VS"]
 
         predicted_xy = _predicted_xy_from_states(sol["X"])
         return MPCStepResult(
@@ -544,7 +587,7 @@ class DubinsPathFollowingMPC(MPCTracker):
             * self.config.horizon_step_count
         )
         # Preview beyond the short prediction horizon at low cruise speeds.
-        return max(horizon_distance * 3.0, 2.0)
+        return max(horizon_distance * 1.5, 2.0)
 
     def _preview_cruise_speed(self, clearance: float) -> float:
         """Reduce cruise when path-ahead clearance is tight.
@@ -607,6 +650,88 @@ class DubinsPathFollowingMPC(MPCTracker):
             samples.append((float(nearest[0]), float(nearest[1])))
         return samples
 
+    def _reference_rollout_init(
+        self,
+        x0_val: np.ndarray,
+        progress: float,
+        preview_cruise: float,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Build an NLP initial guess that rolls forward along the reference.
+
+        The rollout accelerates from the current speed toward the
+        curve-limited reference speed and places the predicted poses on
+        the path itself.  Seeding IPOPT inside this "moving" basin is what
+        lets the solver escape the parked equilibrium at sharp kinks,
+        where a constant-heading or all-stopped guess converges to a
+        full-stop local minimum.
+
+        Args:
+            x0_val: Current state ``(x, y, θ, v, ω)``.
+            progress: Current path progress ``s₀`` (m).
+            preview_cruise: Clearance-limited cruise speed (m/s).
+
+        Returns:
+            ``(X_init, U_init, S_init, VS_init)`` initial-guess arrays.
+        """
+        assert self._reference is not None
+        cfg = self.config
+        limits = self.vehicle_limits
+        n = cfg.horizon_step_count
+        total = self._reference.total_length
+
+        X_init = np.zeros((5, n + 1))
+        U_init = np.zeros((2, n))
+        S_init = np.zeros((1, n + 1))
+        VS_init = np.zeros((1, n))
+        X_init[:, 0] = x0_val
+        S_init[0, 0] = progress
+
+        v = float(np.clip(x0_val[3], limits.min_speed, limits.max_speed))
+        s = float(progress)
+        heading_prev = float(x0_val[2])
+        for k in range(n):
+            kappa = self._reference.curvature(s)
+            v_curve = limits.max_turn_rate / max(abs(kappa), 1e-3)
+            v_target = float(
+                np.clip(
+                    min(preview_cruise, v_curve),
+                    limits.min_speed,
+                    limits.max_speed,
+                )
+            )
+            dv = float(
+                np.clip(
+                    v_target - v,
+                    -limits.max_acceleration * cfg.dt,
+                    limits.max_acceleration * cfg.dt,
+                )
+            )
+            v = v + dv
+            s = min(s + v * cfg.dt, total)
+            x_ref, y_ref = self._reference.position(s)
+            heading_ref = self._reference.heading(s)
+            # Continuous heading guess (unwrap against the previous one).
+            heading_ref = heading_prev + math.atan2(
+                math.sin(heading_ref - heading_prev),
+                math.cos(heading_ref - heading_prev),
+            )
+            omega = float(
+                np.clip(
+                    (heading_ref - heading_prev) / cfg.dt,
+                    -limits.max_turn_rate,
+                    limits.max_turn_rate,
+                )
+            )
+            heading_prev = heading_ref
+            X_init[0, k + 1] = x_ref
+            X_init[1, k + 1] = y_ref
+            X_init[2, k + 1] = heading_ref
+            X_init[3, k + 1] = v
+            X_init[4, k + 1] = omega
+            VS_init[0, k] = v
+            S_init[0, k + 1] = s
+        return X_init, U_init, S_init, VS_init
+
     def _build_nlp(self, obstacle_count: int) -> dict[str, Any]:
         ca = self._ca
         cfg = self.config
@@ -620,19 +745,24 @@ class DubinsPathFollowingMPC(MPCTracker):
         heading_unwrapped = np.unwrap(np.asarray(self._path_heading))
         self._interp_id += 1
         tag = f"mpc{self._interp_id}"
-        fx = ca.interpolant(f"{tag}_x", "linear", [s_grid], self._path_x)
-        fy = ca.interpolant(f"{tag}_y", "linear", [s_grid], self._path_y)
+        # Cubic B-spline interpolants: piecewise-linear reference lookups
+        # have discontinuous gradients exactly at path kinks, which stalls
+        # IPOPT (Maximum_Iterations_Exceeded) right where tracking is
+        # hardest.  Smooth splines also round the polyline at the ~2 m
+        # sample scale, which is desirable for a vehicle-feasible target.
+        fx = ca.interpolant(f"{tag}_x", "bspline", [s_grid], self._path_x)
+        fy = ca.interpolant(f"{tag}_y", "bspline", [s_grid], self._path_y)
         fth = ca.interpolant(
-            f"{tag}_th", "linear", [s_grid], heading_unwrapped
+            f"{tag}_th", "bspline", [s_grid], heading_unwrapped
         )
-        fk = ca.interpolant(f"{tag}_k", "linear", [s_grid], self._path_kappa)
+        fk = ca.interpolant(f"{tag}_k", "bspline", [s_grid], self._path_kappa)
 
         opti = ca.Opti()
         # State: [px, py, theta, v, omega]
         X = opti.variable(5, n + 1)
         U = opti.variable(2, n)  # [a, omega_dot]
-        S = opti.variable(1, n + 1)
-        slack = opti.variable(1, n + 1)
+        S = opti.variable(1, n + 1)  # path parameter (arc length)
+        VS = opti.variable(1, n)  # virtual progress speed ds/dt
 
         x0 = opti.parameter(5)
         s0 = opti.parameter(1)
@@ -643,54 +773,75 @@ class DubinsPathFollowingMPC(MPCTracker):
         opti.subject_to(X[:, 0] == x0)
         opti.subject_to(S[0, 0] == s0)
 
+        def _stage_errors(k: int) -> tuple[Any, Any, Any]:
+            """Contouring / lag / heading errors at stage *k*."""
+            x_ref = fx(S[0, k])
+            y_ref = fy(S[0, k])
+            th_ref = fth(S[0, k])
+            dx = X[0, k] - x_ref
+            dy = X[1, k] - y_ref
+            e_contour = -dx * ca.sin(th_ref) + dy * ca.cos(th_ref)
+            e_lag = dx * ca.cos(th_ref) + dy * ca.sin(th_ref)
+            e_head = X[2, k] - th_ref
+            return e_contour, e_lag, e_head
+
         cost = 0
         for k in range(n):
-            px = X[0, k]
-            py = X[1, k]
-            theta = X[2, k]
             v = X[3, k]
+            theta = X[2, k]
             omega = X[4, k]
             a = U[0, k]
             omega_dot = U[1, k]
-            s_k = S[0, k]
+            v_s = VS[0, k]
 
-            x_ref = fx(s_k)
-            y_ref = fy(s_k)
-            th_ref = fth(s_k)
-            kappa = fk(s_k)
-            e_lat = -(px - x_ref) * ca.sin(th_ref) + (py - y_ref) * ca.cos(
-                th_ref
-            )
-            e_head = theta - th_ref
+            e_contour, e_lag, e_head = _stage_errors(k)
             e_head_cost = ca.sin(e_head) ** 2 + (1.0 - ca.cos(e_head)) ** 2
 
-            v_curve = limits.max_turn_rate / ca.fmax(ca.fabs(kappa), 1e-3)
-            v_ref = ca.fmin(cruise_p, v_curve)
-            v_ref = ca.fmax(limits.min_speed, ca.fmin(limits.max_speed, v_ref))
+            kappa = fk(S[0, k])
+            # Curve-limited progress cap, written as two smooth
+            # inequalities (no fmin/fabs kinks in the constraint set):
+            #   v_s ≤ cruise   and   v_s·|κ| ≤ ω_max  ⇔  v_s ≤ ω_max/|κ|.
+            opti.subject_to(v_s <= cruise_p)
+            opti.subject_to(
+                v_s * ca.sqrt(kappa**2 + 1e-6) <= limits.max_turn_rate
+            )
 
             # Free lateral band: only the excess beyond the deadzone is
-            # penalized, so the solver may widen a sharp corner as long as
-            # arc-length progress (lag term below) keeps advancing.
-            e_lat_excess = ca.fmax(ca.fabs(e_lat) - cfg.contour_deadzone, 0.0)
-            cost += cfg.weight_contour * e_lat_excess**2
+            # penalized.  The zero-deadzone default uses the plain smooth
+            # quadratic (no fabs/fmax kink at e_contour = 0).
+            if cfg.contour_deadzone > 0.0:
+                e_c_excess = ca.fmax(
+                    ca.fabs(e_contour) - cfg.contour_deadzone, 0
+                )
+                cost += cfg.weight_contour * e_c_excess**2
+            else:
+                cost += cfg.weight_contour * e_contour**2
+            cost += cfg.weight_lag * e_lag**2
             cost += cfg.weight_heading * e_head_cost
-            cost += cfg.weight_progress * (v_ref - v) ** 2
-            s_target = ca.fmin(
-                s0 + cruise_p * float(k) * dt,
-                self._reference.total_length,
-            )
-            # Penalize being behind schedule only — being ahead is fine.
-            cost += cfg.weight_lag * ca.fmax(s_target - s_k, 0.0) ** 2
+            # Progress: LINEAR advancement reward (classical MPCC).  A
+            # quadratic (v_s − v_ref)² speed-matching term is a trap: at a
+            # sharp kink v_ref(s) is small, so parking at the kink costs
+            # almost nothing while accelerating away looks expensive over
+            # the horizon — the solver then prefers a permanent full stop.
+            # A linear reward makes advancement pay everywhere; the hard
+            # v_s ≤ v_ref cap above keeps corner braking feed-forward.
+            cost -= cfg.weight_progress * v_s * dt
             cost += cfg.weight_control * (a**2 + omega_dot**2)
-            cost += cfg.weight_slack * slack[0, k] ** 2
 
             if obs is not None:
+                px = X[0, k]
+                py = X[1, k]
                 for j in range(obstacle_count):
                     ox = obs[0, j]
                     oy = obs[1, j]
                     dist = ca.sqrt((px - ox) ** 2 + (py - oy) ** 2 + 1e-9)
-                    bearing = ca.atan2(oy - py, ox - px)
-                    cone = ca.fmax(0.0, ca.cos(theta - bearing))
+                    # Smooth forward-cone factor (no atan2 kinks): the
+                    # projection of the unit obstacle bearing onto the
+                    # vehicle heading, clamped to [0, 1].
+                    fwd = (
+                        ca.cos(theta) * (ox - px) + ca.sin(theta) * (oy - py)
+                    ) / dist
+                    cone = ca.fmax(0.0, fwd)
                     penetration = (clearance_p - dist) / ca.fmax(
                         clearance_p, 1e-6
                     )
@@ -704,17 +855,15 @@ class DubinsPathFollowingMPC(MPCTracker):
 
             v_next = v + a * dt
             omega_next = omega + omega_dot * dt
-            opti.subject_to(X[0, k + 1] == px + v * ca.cos(theta) * dt)
-            opti.subject_to(X[1, k + 1] == py + v * ca.sin(theta) * dt)
+            opti.subject_to(X[0, k + 1] == X[0, k] + v * ca.cos(theta) * dt)
+            opti.subject_to(X[1, k + 1] == X[1, k] + v * ca.sin(theta) * dt)
             opti.subject_to(X[2, k + 1] == theta + omega * dt)
             opti.subject_to(X[3, k + 1] == v_next)
             opti.subject_to(X[4, k + 1] == omega_next)
-            # Contouring progress must not reverse when |e_ψ| > 90°.
-            # With ṡ = v cos(e_ψ) a recovery / wider arc drove s backward,
-            # which is the limit-cycle that trapped the city A* racer.
-            opti.subject_to(
-                S[0, k + 1] == s_k + v * ca.fmax(ca.cos(e_head), 0.0) * dt
-            )
+            # Virtual progress dynamics: s advances with its own bounded
+            # speed decision variable (classical MPCC progress law).
+            opti.subject_to(S[0, k + 1] == S[0, k] + v_s * dt)
+            opti.subject_to(opti.bounded(0.0, v_s, limits.max_speed))
 
             opti.subject_to(
                 opti.bounded(limits.min_speed, v_next, limits.max_speed)
@@ -736,32 +885,21 @@ class DubinsPathFollowingMPC(MPCTracker):
                     limits.max_turn_rate_dot,
                 )
             )
-            opti.subject_to(slack[0, k] >= 0)
             opti.subject_to(
-                opti.bounded(0.0, S[0, k], self._reference.total_length + 1.0)
+                opti.bounded(0.0, S[0, k], self._reference.total_length)
             )
 
-        px_n = X[0, n]
-        py_n = X[1, n]
-        theta_n = X[2, n]
-        s_n = S[0, n]
-        x_ref_n = fx(s_n)
-        y_ref_n = fy(s_n)
-        th_ref_n = fth(s_n)
-        e_lat_n = -(px_n - x_ref_n) * ca.sin(th_ref_n) + (
-            py_n - y_ref_n
-        ) * ca.cos(th_ref_n)
-        e_head_n = theta_n - th_ref_n
+        e_contour_n, e_lag_n, e_head_n = _stage_errors(n)
         e_head_n_cost = ca.sin(e_head_n) ** 2 + (1.0 - ca.cos(e_head_n)) ** 2
-        e_lat_n_excess = ca.fmax(ca.fabs(e_lat_n) - cfg.contour_deadzone, 0.0)
-        cost += cfg.weight_terminal * (e_lat_n_excess**2 + e_head_n_cost)
-        s_target_n = ca.fmin(
-            s0 + cruise_p * float(n) * dt,
-            self._reference.total_length,
-        )
-        cost += cfg.weight_lag * ca.fmax(s_target_n - s_n, 0.0) ** 2
-        cost += cfg.weight_slack * slack[0, n] ** 2
-        opti.subject_to(slack[0, n] >= 0)
+        if cfg.contour_deadzone > 0.0:
+            e_c_n_excess = ca.fmax(
+                ca.fabs(e_contour_n) - cfg.contour_deadzone, 0.0
+            )
+            e_c_n_cost = e_c_n_excess**2
+        else:
+            e_c_n_cost = e_contour_n**2
+        cost += cfg.weight_terminal * (e_c_n_cost + e_head_n_cost)
+        cost += cfg.weight_lag * e_lag_n**2
         opti.subject_to(
             opti.bounded(limits.min_speed, X[3, n], limits.max_speed)
         )
@@ -769,7 +907,7 @@ class DubinsPathFollowingMPC(MPCTracker):
             opti.bounded(-limits.max_turn_rate, X[4, n], limits.max_turn_rate)
         )
         opti.subject_to(
-            opti.bounded(0.0, S[0, n], self._reference.total_length + 1.0)
+            opti.bounded(0.0, S[0, n], self._reference.total_length)
         )
 
         opti.minimize(cost)
@@ -781,6 +919,8 @@ class DubinsPathFollowingMPC(MPCTracker):
                 "ipopt.max_iter": int(cfg.max_solver_iter_count),
                 "ipopt.sb": "yes",
                 "ipopt.tol": 1e-4,
+                "ipopt.acceptable_tol": 1e-2,
+                "ipopt.acceptable_iter": 5,
                 "ipopt.warm_start_init_point": "yes",
             },
         )
@@ -789,7 +929,7 @@ class DubinsPathFollowingMPC(MPCTracker):
             "X": X,
             "U": U,
             "S": S,
-            "slack": slack,
+            "VS": VS,
             "x0": x0,
             "s0": s0,
             "obs": obs,
@@ -829,6 +969,7 @@ class DubinsPathFollowingMPC(MPCTracker):
         X = nlp["X"]
         U = nlp["U"]
         S = nlp["S"]
+        VS = nlp["VS"]
 
         x0_val = np.array(
             [pose[0], pose[1], pose[2], speed, turn_rate], dtype=float
@@ -842,35 +983,48 @@ class DubinsPathFollowingMPC(MPCTracker):
             obs_mat = np.array(obstacles, dtype=float).T
             opti.set_value(nlp["obs"], obs_mat)
 
-        if self._warm_x is not None and self._warm_x.shape == (5, n + 1):
+        # Shifted warm start while the previous solution keeps moving.  A
+        # stalled warm start (near-zero progress over the horizon while
+        # the reference ahead allows motion) would re-seed IPOPT inside
+        # the parked local minimum forever — use a fresh reference rollout
+        # instead so the solver can compare against the moving basin.
+        warm_available = (
+            self._warm_x is not None
+            and self._warm_x.shape == (5, n + 1)
+            and self._warm_vs is not None
+        )
+        warm_ok = False
+        if warm_available:
+            warm_advance = float(self._warm_s[0, -1] - self._warm_s[0, 0])
+            horizon_advance = float(preview_cruise) * cfg.dt * n
+            near_goal = (
+                self._reference.total_length - progress
+            ) < horizon_advance
+            warm_ok = (
+                warm_advance > max(1.0, 0.1 * horizon_advance)
+                or preview_cruise <= limits.min_speed + 1e-9
+                or near_goal
+            )
+        if warm_ok:
             X_init = np.hstack([self._warm_x[:, 1:], self._warm_x[:, -1:]])
             U_init = np.hstack([self._warm_u[:, 1:], self._warm_u[:, -1:]])
             S_init = np.hstack([self._warm_s[:, 1:], self._warm_s[:, -1:]])
+            VS_init = np.hstack([self._warm_vs[:, 1:], self._warm_vs[:, -1:]])
             X_init[:, 0] = x0_val
             S_init[0, 0] = progress
+            # Keep the shifted progress column consistent with s0.
+            S_init[0, 1:] = np.maximum(S_init[0, 1:], progress)
         else:
-            X_init = np.zeros((5, n + 1))
-            U_init = np.zeros((2, n))
-            S_init = np.zeros((1, n + 1))
-            X_init[:, 0] = x0_val
-            S_init[0, 0] = progress
-            v0 = float(np.clip(speed, limits.min_speed, limits.max_speed))
-            for k in range(n):
-                theta = X_init[2, k]
-                X_init[0, k + 1] = X_init[0, k] + v0 * math.cos(theta) * cfg.dt
-                X_init[1, k + 1] = X_init[1, k] + v0 * math.sin(theta) * cfg.dt
-                X_init[2, k + 1] = theta
-                X_init[3, k + 1] = v0
-                X_init[4, k + 1] = 0.0
-                S_init[0, k + 1] = min(
-                    progress + v0 * cfg.dt * (k + 1),
-                    self._reference.total_length,
-                )
+            X_init, U_init, S_init, VS_init = self._reference_rollout_init(
+                x0_val, progress, preview_cruise
+            )
 
+        S_init = np.clip(S_init, 0.0, self._reference.total_length)
+        VS_init = np.clip(VS_init, 0.0, limits.max_speed)
         opti.set_initial(X, X_init)
         opti.set_initial(U, U_init)
         opti.set_initial(S, S_init)
-        opti.set_initial(nlp["slack"], np.zeros((1, n + 1)))
+        opti.set_initial(VS, VS_init)
 
         try:
             sol = opti.solve()
@@ -880,6 +1034,7 @@ class DubinsPathFollowingMPC(MPCTracker):
         X_opt = np.array(sol.value(X), dtype=float)
         U_opt = np.array(sol.value(U), dtype=float)
         S_opt = np.array(sol.value(S), dtype=float).reshape(1, n + 1)
+        VS_opt = np.array(sol.value(VS), dtype=float).reshape(1, n)
         speed_cmd = float(
             np.clip(X_opt[3, 1], limits.min_speed, limits.max_speed)
         )
@@ -914,4 +1069,5 @@ class DubinsPathFollowingMPC(MPCTracker):
             "X": X_opt,
             "U": U_opt,
             "S": S_opt,
+            "VS": VS_opt,
         }

--- a/src/arco/control/mpc/reference_path.py
+++ b/src/arco/control/mpc/reference_path.py
@@ -79,10 +79,12 @@ class ReferencePath:
     _CURVATURE_DS_FLOOR_M: float = 8.0
     # Hard cap on |κ| (1/m) after preview — safety net for the NLP.
     _CURVATURE_ABS_MAX: float = 0.35
-    # Backward horizon (m) over which an upcoming corner κ is visible so the
-    # NMPC can decelerate before the kink (≈ cruise² / (2 a) at city soft
-    # limits).
-    _CURVATURE_PREVIEW_DS_M: float = 40.0
+    # Backward horizon (m) over which an upcoming corner κ is visible on
+    # the approach.  Kept short: the MPCC's receding horizon (several
+    # seconds) already previews corner speed caps and plans braking, so a
+    # long κ preview only double-counts the conservatism and drags cruise
+    # down everywhere between corners.
+    _CURVATURE_PREVIEW_DS_M: float = 12.0
 
     @classmethod
     def _finite_difference_curvature(

--- a/src/arco/guidance/interpolation/__init__.py
+++ b/src/arco/guidance/interpolation/__init__.py
@@ -2,8 +2,10 @@
 
 from .base import Interpolator
 from .bspline import BSplineInterpolator
+from .moving_average import MovingAverageInterpolator
 
 __all__ = [
     "BSplineInterpolator",
     "Interpolator",
+    "MovingAverageInterpolator",
 ]

--- a/src/arco/guidance/interpolation/moving_average.py
+++ b/src/arco/guidance/interpolation/moving_average.py
@@ -1,0 +1,62 @@
+"""MovingAverageInterpolator: endpoint-preserving polyline smoothing."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import numpy as np
+
+from .base import Interpolator
+
+
+class MovingAverageInterpolator(Interpolator):
+    """Sliding-window moving-average smoothing of a waypoint polyline.
+
+    Filters the high-frequency lateral wiggle that sampling planners
+    (RRT*, SST) and grid staircases (A*) leave in their waypoint lists.
+    Endpoints are preserved exactly; interior points are replaced by the
+    window mean.  Repeated iterations increase the smoothing strength.
+
+    The filter only ever pulls points toward the local chord, so lateral
+    excursions shrink — but sharp real corners are also cut slightly.
+    Callers tracking through obstacle fields should verify clearance
+    after smoothing (see ``CityScene`` for a guarded application).
+    """
+
+    def __init__(self, *, iterations: int = 1, window: int = 3) -> None:
+        """Initialize the moving-average smoother.
+
+        Args:
+            iterations: Number of smoothing passes (at least 1).
+            window: Odd window size in waypoints (at least 3).
+
+        Raises:
+            ValueError: If *window* is even or smaller than 3.
+        """
+        if window < 3 or window % 2 == 0:
+            raise ValueError("window must be an odd integer >= 3.")
+        self.iterations = max(int(iterations), 1)
+        self.window = int(window)
+
+    def interpolate(self, path: List[Any]) -> List[Any]:
+        """Smooth a discrete path with repeated moving-average passes.
+
+        Args:
+            path: A list of discrete waypoints (``(x, y)``-like).
+
+        Returns:
+            A list of ``(x, y)`` tuples with identical first and last
+            points; inputs shorter than 3 points are returned unchanged.
+        """
+        if len(path) < 3:
+            return list(path)
+        pts = np.asarray([(float(p[0]), float(p[1])) for p in path])
+        half = self.window // 2
+        for _ in range(self.iterations):
+            smoothed = pts.copy()
+            for i in range(1, len(pts) - 1):
+                lo = max(0, i - half)
+                hi = min(len(pts), i + half + 1)
+                smoothed[i] = pts[lo:hi].mean(axis=0)
+            pts = smoothed
+        return [(float(p[0]), float(p[1])) for p in pts]

--- a/src/arco/simulator/main/city.py
+++ b/src/arco/simulator/main/city.py
@@ -57,6 +57,7 @@ from arco.simulator import renderer_gl
 from arco.simulator.scenes import RaceScene
 from arco.simulator.scenes.sparse import CityScene
 from arco.simulator.sim.camera import CameraFilter
+from arco.simulator.sim.car_sprite import draw_car_sprite, reset_texture_cache
 from arco.simulator.sim.city_race_style import (
     DEFAULT_CITY_HORIZON_DT,
     DEFAULT_CITY_HORIZON_STEP_COUNT,
@@ -162,7 +163,7 @@ def _draw_race_vehicle(
     heading: float,
     color: tuple[int, int, int],
 ) -> None:
-    """Draw a race agent as a bright oriented rectangle (not a disc).
+    """Draw a race agent as a GTA2-style top-down car sprite.
 
     Args:
         x: Vehicle x position in world meters.
@@ -170,14 +171,7 @@ def _draw_race_vehicle(
         heading: Vehicle heading in radians.
         color: Base RGB body color in ``[0, 255]``.
     """
-    renderer_gl.draw_oriented_rect(
-        x,
-        y,
-        VEH_HALF_L,
-        VEH_HALF_W,
-        heading,
-        *_brighten_rgb(color, mix=0.65),
-    )
+    draw_car_sprite(x, y, heading, VEH_HALF_L, VEH_HALF_W, color)
 
 
 def _draw_winner_banner(
@@ -1018,6 +1012,8 @@ def run_race(
     finally:
         if writer is not None:
             writer.close()
+        # Sprite textures die with the GL context — drop the cached ids.
+        reset_texture_cache()
         pygame.quit()
 
 

--- a/src/arco/simulator/main/occ.py
+++ b/src/arco/simulator/main/occ.py
@@ -50,6 +50,7 @@ from arco.simulator.sim.layout import (
     paint_sidebar_panel,
     scenario_phase_title,
 )
+from arco.simulator.sim.tracking import resolve_sim_timestep
 from arco.simulator.sim.video import VideoWriter
 
 logger = logging.getLogger(__name__)
@@ -430,7 +431,7 @@ def main(cfg: dict, save_path: str | None, sim_duration: float) -> None:
     env_cfg: dict = cfg.get("environment", {})
     ctrl_cfg: dict = cfg.get("control", {})
     sim_cfg: dict = load_config("simulator")
-    dt = sim_cfg["timestep"]
+    dt = resolve_sim_timestep(cfg, global_sim_cfg=sim_cfg)
     fps = sim_cfg["fps"]
 
     pygame.init()

--- a/src/arco/simulator/main/ppp.py
+++ b/src/arco/simulator/main/ppp.py
@@ -124,7 +124,12 @@ from arco.simulator.sim.layout import (
     scenario_phase_title,
 )
 from arco.simulator.sim.loading import run_with_loading_screen
-from arco.simulator.sim.tracking import build_joint_tracker
+from arco.simulator.sim.tracking import (
+    DEFAULT_JOINT_HORIZON_STEP_COUNT,
+    build_joint_tracker,
+    joint_space_mpc_config_from_simulator,
+    resolve_sim_timestep,
+)
 from arco.simulator.sim.video import VideoWriter
 
 logger = logging.getLogger(__name__)
@@ -1008,6 +1013,11 @@ def run_race(
     proportional_gain = float(sim_cfg.get("proportional_gain", 2.0))
     repulsion_gain = float(sim_cfg.get("repulsion_gain", 0.0))
     tracker_mode = str(sim_cfg.get("tracker", "pure_pursuit"))
+    mpc_cfg = joint_space_mpc_config_from_simulator(
+        sim_cfg,
+        default_horizon_step_count=DEFAULT_JOINT_HORIZON_STEP_COUNT,
+        default_horizon_dt=dt,
+    )
 
     pygame.init()
     sw, sh = _DEFAULT_SCREEN_W, _DEFAULT_SCREEN_H
@@ -1057,6 +1067,7 @@ def run_race(
         occupancy=scene.occ,
         repulsion_gain=repulsion_gain,
         tracker=tracker_mode,
+        mpc_cfg=mpc_cfg,
     )
     rrt_robot.reset(scene.start)
     sst_robot = build_joint_tracker(
@@ -1066,6 +1077,7 @@ def run_race(
         occupancy=scene.occ,
         repulsion_gain=repulsion_gain,
         tracker=tracker_mode,
+        mpc_cfg=mpc_cfg,
     )
     sst_robot.reset(scene.start)
     rrt_carrot_dist = 0.0
@@ -1375,12 +1387,14 @@ def run_race(
 
 def main(cfg: dict, save_path: str | None, sim_duration: float) -> None:
     sim_cfg = load_config("simulator")
+    dt = resolve_sim_timestep(cfg, global_sim_cfg=sim_cfg)
 
     scene = PPPScene(cfg)
     run_race(
         scene,
         cfg,
         fps=sim_cfg["fps"],
+        dt=dt,
         record=save_path,
         record_duration=sim_duration,
     )

--- a/src/arco/simulator/main/rrp.py
+++ b/src/arco/simulator/main/rrp.py
@@ -125,7 +125,12 @@ from arco.simulator.sim.layout import (
     scenario_phase_title,
 )
 from arco.simulator.sim.loading import run_with_loading_screen
-from arco.simulator.sim.tracking import build_joint_tracker
+from arco.simulator.sim.tracking import (
+    DEFAULT_JOINT_HORIZON_STEP_COUNT,
+    build_joint_tracker,
+    joint_space_mpc_config_from_simulator,
+    resolve_sim_timestep,
+)
 from arco.simulator.sim.video import VideoWriter
 
 logger = logging.getLogger(__name__)
@@ -972,6 +977,11 @@ def run_race(
     max_lin_acc = float(sim_cfg.get("max_lin_acc", 2.0))
     repulsion_gain = float(sim_cfg.get("repulsion_gain", 0.0))
     tracker_mode = str(sim_cfg.get("tracker", "pure_pursuit"))
+    mpc_cfg = joint_space_mpc_config_from_simulator(
+        sim_cfg,
+        default_horizon_step_count=DEFAULT_JOINT_HORIZON_STEP_COUNT,
+        default_horizon_dt=dt,
+    )
 
     pygame.init()
     sw, sh = _DEFAULT_SCREEN_W, _DEFAULT_SCREEN_H
@@ -1022,6 +1032,7 @@ def run_race(
         occupancy=scene.occ,
         repulsion_gain=repulsion_gain,
         tracker=tracker_mode,
+        mpc_cfg=mpc_cfg,
     )
     rrt_robot.reset(scene.start_q)
     sst_robot = build_joint_tracker(
@@ -1030,6 +1041,7 @@ def run_race(
         occupancy=scene.occ,
         repulsion_gain=repulsion_gain,
         tracker=tracker_mode,
+        mpc_cfg=mpc_cfg,
     )
     sst_robot.reset(scene.start_q)
     rrt_carrot_dist = 0.0
@@ -1383,11 +1395,13 @@ def run_race(
 
 def main(cfg: dict, save_path: str | None, sim_duration: float) -> None:
     sim_cfg = load_config("simulator")
+    dt = resolve_sim_timestep(cfg, global_sim_cfg=sim_cfg)
     scene = RRPScene(cfg)
     run_race(
         scene,
         cfg,
         fps=sim_cfg["fps"],
+        dt=dt,
         record=save_path,
         record_duration=sim_duration,
     )

--- a/src/arco/simulator/scenes/sparse.py
+++ b/src/arco/simulator/scenes/sparse.py
@@ -331,6 +331,78 @@ def _coerce_astar_cell_size(
     return float(step_size) / 5.0
 
 
+def _min_polyline_clearance(
+    points: list[Any],
+    occ: Any,
+    *,
+    sample_spacing: float = 2.0,
+) -> float:
+    """Minimum obstacle clearance along a polyline, sampled densely.
+
+    Args:
+        points: Ordered waypoints supporting ``[0]`` / ``[1]`` access.
+        occ: Occupancy exposing ``nearest_obstacle(point)``.
+        sample_spacing: Arc-length sampling step in meters.
+
+    Returns:
+        Minimum distance to the obstacle cloud (``inf`` for < 2 points).
+    """
+    if len(points) < 2:
+        return float("inf")
+    min_dist = float("inf")
+    for i in range(len(points) - 1):
+        p0 = np.asarray(points[i][:2], dtype=float)
+        p1 = np.asarray(points[i + 1][:2], dtype=float)
+        seg_len = float(np.linalg.norm(p1 - p0))
+        n_samples = max(1, int(seg_len / sample_spacing))
+        for k in range(n_samples + 1):
+            pt = p0 + (p1 - p0) * (k / max(n_samples, 1))
+            dist, _ = occ.nearest_obstacle(pt)
+            min_dist = min(min_dist, float(dist))
+    return min_dist
+
+
+def _smooth_reference(
+    traj: list[Any],
+    occ: Any,
+    *,
+    iterations: int = 2,
+    clearance_keep_ratio: float = 0.9,
+) -> list[Any]:
+    """Smooth a racer reference, reverting if clearance degrades.
+
+    Sampling planners (RRT*, SST) and grid staircases (A*) leave a
+    high-frequency lateral wiggle in the optimized trajectory.  Tracking
+    that wiggle forces the MPCC's curve-limited progress cap down along
+    the whole route, which reads as a crawling car.  A short moving
+    average removes the wiggle; the clearance guard rejects the smoothed
+    version whenever it cuts a real corner meaningfully closer to the
+    buildings than the original.
+
+    Args:
+        traj: Optimized trajectory waypoints.
+        occ: Occupancy for the clearance guard.
+        iterations: Moving-average passes.
+        clearance_keep_ratio: Minimum acceptable ratio of smoothed to
+            original minimum clearance.
+
+    Returns:
+        Smoothed waypoints (``(x, y)`` tuples), or the original list
+        when smoothing would reduce minimum clearance below the guard.
+    """
+    from arco.guidance.interpolation import MovingAverageInterpolator
+
+    if len(traj) < 3:
+        return traj
+    smoother = MovingAverageInterpolator(iterations=iterations)
+    smoothed = smoother.interpolate(traj)
+    original_clearance = _min_polyline_clearance(traj, occ)
+    smoothed_clearance = _min_polyline_clearance(smoothed, occ)
+    if smoothed_clearance < clearance_keep_ratio * original_clearance:
+        return traj
+    return smoothed
+
+
 def _c(t: tuple[int, int, int]) -> tuple[float, float, float]:
     return (t[0] / 255.0, t[1] / 255.0, t[2] / 255.0)
 
@@ -687,6 +759,7 @@ class CityScene(RaceScene):
             pr = pipeline.run_from_path(path)
             pruned = pr.pruned_path if pr.pruned_path is not None else path
             traj = pr.trajectory if pr.trajectory else list(pruned)
+            traj = _smooth_reference(traj, self._occ)
             setattr(self, path_attr, pruned)
             setattr(self, traj_attr, traj)
             getattr(self, metrics_attr).update(

--- a/src/arco/simulator/sim/car_sprite.py
+++ b/src/arco/simulator/sim/car_sprite.py
@@ -1,0 +1,237 @@
+"""Procedural GTA2-style top-down car sprites for race vehicles.
+
+Generates small pixel-art car sprites (body colored per racer, dark
+glass, black tires, head/taillights) as pygame surfaces, uploads them as
+OpenGL textures on first use, and draws them as oriented textured quads
+in world coordinates.
+
+Surface generation is pure pygame (no GL context required) so it stays
+unit-testable on headless CI runners; only :func:`draw_car_sprite`
+touches OpenGL state.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pygame
+from OpenGL.GL import (  # type: ignore[import-untyped]
+    GL_MODULATE,
+    GL_NEAREST,
+    GL_QUADS,
+    GL_RGBA,
+    GL_TEXTURE_2D,
+    GL_TEXTURE_ENV,
+    GL_TEXTURE_ENV_MODE,
+    GL_TEXTURE_MAG_FILTER,
+    GL_TEXTURE_MIN_FILTER,
+    GL_UNSIGNED_BYTE,
+    glBegin,
+    glBindTexture,
+    glColor4f,
+    glDisable,
+    glEnable,
+    glEnd,
+    glGenTextures,
+    glTexCoord2f,
+    glTexEnvf,
+    glTexImage2D,
+    glTexParameteri,
+    glVertex2f,
+)
+
+# Logical pixel grid of the sprite: car points +X (heading = 0 = east).
+_GRID_L = 24
+_GRID_W = 12
+# Upscale factor from the logical grid to the generated surface.
+_SPRITE_SCALE = 4
+
+# Fixed palette parts (RGB).
+_C_TIRE = (42, 44, 50)
+_C_GLASS = (52, 74, 94)
+_C_GLASS_HI = (86, 116, 140)
+_C_HEADLIGHT = (255, 244, 176)
+_C_TAILLIGHT = (208, 48, 40)
+_C_OUTLINE = (16, 16, 20)
+
+_texture_cache: dict[tuple[int, int, int], int] = {}
+
+
+def _mix(
+    a: tuple[int, int, int], b: tuple[int, int, int], t: float
+) -> tuple[int, int, int]:
+    """Linearly interpolate two RGB colors.
+
+    Args:
+        a: Start color.
+        b: End color.
+        t: Blend factor in ``[0, 1]`` (0 → *a*, 1 → *b*).
+
+    Returns:
+        Blended RGB tuple.
+    """
+    t = float(min(max(t, 0.0), 1.0))
+    return (
+        int(round(a[0] + (b[0] - a[0]) * t)),
+        int(round(a[1] + (b[1] - a[1]) * t)),
+        int(round(a[2] + (b[2] - a[2]) * t)),
+    )
+
+
+def make_car_sprite_surface(
+    color: tuple[int, int, int],
+    *,
+    scale: int = _SPRITE_SCALE,
+) -> pygame.Surface:
+    """Build a GTA2-style top-down car sprite pointing east (+X).
+
+    The sprite is drawn on a ``24 × 12`` logical pixel grid (length ×
+    width) and upscaled with nearest-neighbor so the pixel-art look
+    survives: black outline and tires, per-racer body color with hood /
+    roof shading, dark windshield and rear glass, pale headlights, and
+    red taillights.
+
+    Args:
+        color: Base body RGB color in ``[0, 255]``.
+        scale: Integer upscale factor from the logical grid.
+
+    Returns:
+        ``pygame.Surface`` with per-pixel alpha, size
+        ``(24 · scale, 12 · scale)``.
+    """
+    body = _mix(color, (255, 255, 255), 0.20)
+    body_dark = _mix(color, (0, 0, 0), 0.35)
+    roof = _mix(color, (255, 255, 255), 0.42)
+    roof_edge = _mix(color, (255, 255, 255), 0.05)
+
+    surf = pygame.Surface((_GRID_L, _GRID_W), pygame.SRCALPHA)
+    surf.fill((0, 0, 0, 0))
+
+    def px(x: int, y: int, c: tuple[int, int, int]) -> None:
+        surf.set_at((x, y), (*c, 255))
+
+    def rect(x0: int, y0: int, x1: int, y1: int, c) -> None:
+        for x in range(x0, x1 + 1):
+            for y in range(y0, y1 + 1):
+                px(x, y, c)
+
+    # Body outline (rows 1..10), rounded by trimming the four corners.
+    rect(0, 1, 23, 10, _C_OUTLINE)
+
+    # Body fill inside the outline.
+    rect(1, 2, 22, 9, body)
+
+    # Rounded nose and tail: trim outline corners to transparent and pull
+    # the fill corners back to outline so the silhouette curves.
+    for x, y in ((0, 1), (0, 10), (23, 1), (23, 10)):
+        surf.set_at((x, y), (0, 0, 0, 0))
+    for x, y in ((1, 2), (1, 9), (22, 2), (22, 9)):
+        px(x, y, _C_OUTLINE)
+
+    # Body side shading rows for a hint of volume.
+    rect(2, 2, 21, 2, body_dark)
+    rect(2, 9, 21, 9, body_dark)
+
+    # Hood highlight (front deck) and a subtle trunk panel.
+    rect(17, 4, 20, 7, roof_edge)
+    rect(3, 4, 5, 7, roof_edge)
+
+    # Tires — black blocks poking outside the body, drawn over it.
+    rect(3, 0, 6, 1, _C_TIRE)
+    rect(3, 10, 6, 11, _C_TIRE)
+    rect(16, 0, 19, 1, _C_TIRE)
+    rect(16, 10, 19, 11, _C_TIRE)
+
+    # Cabin: dark glass inset with body-colored pillars left visible.
+    rect(14, 3, 15, 8, _C_GLASS)  # windshield (front of cabin)
+    rect(14, 4, 14, 7, _C_GLASS_HI)
+    rect(7, 3, 8, 8, _C_GLASS)  # rear window
+    rect(9, 3, 12, 3, _C_GLASS)  # side windows
+    rect(9, 8, 12, 8, _C_GLASS)
+
+    # Cabin roof between the glass panes, lighter center.
+    rect(9, 4, 12, 7, roof)
+
+    # Headlights (front = +X) and taillights (rear).
+    rect(22, 3, 22, 4, _C_HEADLIGHT)
+    rect(22, 7, 22, 8, _C_HEADLIGHT)
+    rect(1, 3, 1, 4, _C_TAILLIGHT)
+    rect(1, 7, 1, 8, _C_TAILLIGHT)
+
+    scale = max(int(scale), 1)
+    return pygame.transform.scale(surf, (_GRID_L * scale, _GRID_W * scale))
+
+
+def _get_car_texture(color: tuple[int, int, int]) -> int:
+    """Return (building if needed) the GL texture for a body color.
+
+    Args:
+        color: Base body RGB color in ``[0, 255]``.
+
+    Returns:
+        OpenGL texture id.
+    """
+    key = (int(color[0]), int(color[1]), int(color[2]))
+    tex_id = _texture_cache.get(key)
+    if tex_id is not None:
+        return tex_id
+    surf = make_car_sprite_surface(key)
+    w, h = surf.get_size()
+    data = pygame.image.tostring(surf, "RGBA", True)
+    tex_id = int(glGenTextures(1))
+    glBindTexture(GL_TEXTURE_2D, tex_id)
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
+    glTexImage2D(
+        GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, data
+    )
+    glBindTexture(GL_TEXTURE_2D, 0)
+    _texture_cache[key] = tex_id
+    return tex_id
+
+
+def reset_texture_cache() -> None:
+    """Forget cached texture ids (call after the GL context is torn down)."""
+    _texture_cache.clear()
+
+
+def draw_car_sprite(
+    x: float,
+    y: float,
+    heading: float,
+    half_l: float,
+    half_w: float,
+    color: tuple[int, int, int],
+) -> None:
+    """Draw a car sprite as an oriented textured quad in world meters.
+
+    Args:
+        x: Vehicle center x in world meters.
+        y: Vehicle center y in world meters.
+        heading: Vehicle heading in radians (0 = east).
+        half_l: Half-length (forward) in world meters.
+        half_w: Half-width (lateral) in world meters.
+        color: Base body RGB color in ``[0, 255]``.
+    """
+    tex_id = _get_car_texture(color)
+    cos_h = math.cos(heading)
+    sin_h = math.sin(heading)
+    # Local corners (front-left, front-right, rear-right, rear-left) and
+    # matching texture coordinates: +X in sprite space is the car front.
+    corners = (
+        (half_l, half_w, 1.0, 1.0),
+        (half_l, -half_w, 1.0, 0.0),
+        (-half_l, -half_w, 0.0, 0.0),
+        (-half_l, half_w, 0.0, 1.0),
+    )
+    glEnable(GL_TEXTURE_2D)
+    glBindTexture(GL_TEXTURE_2D, tex_id)
+    glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE)
+    glColor4f(1.0, 1.0, 1.0, 1.0)
+    glBegin(GL_QUADS)
+    for lx, ly, u, v in corners:
+        glTexCoord2f(u, v)
+        glVertex2f(x + lx * cos_h - ly * sin_h, y + lx * sin_h + ly * cos_h)
+    glEnd()
+    glBindTexture(GL_TEXTURE_2D, 0)
+    glDisable(GL_TEXTURE_2D)

--- a/src/arco/simulator/sim/city_race_style.py
+++ b/src/arco/simulator/sim/city_race_style.py
@@ -13,11 +13,15 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from arco.simulator.sim.tracking import VehicleConfig
 
-# Vehicle body half-extents in world meters.
-# Prior city glyph was 3.0 × 1.4 m; ~2.5× keeps a clear rectangle on the map
-# without restoring the old oversized glow blobs.
-VEH_HALF_L: float = 8.0
-VEH_HALF_W: float = 3.6
+# Vehicle body half-extents in world meters (12 × 5.4 m car).
+# Large enough to read clearly in the ~200 m follow-cam window, small
+# enough that the sprite's nose no longer sweeps over inner-corner
+# building points on routes that legitimately pass ~7.7 m from them
+# (the prior 16 m-long glyph visually clipped corners the tracker
+# cleared).  Ratio 20:9 matches the 24 × 12 sprite pixel grid with the
+# rounded nose/tail trimmed.
+VEH_HALF_L: float = 6.0
+VEH_HALF_W: float = 2.7
 
 # Small Pure-Pursuit carrot disc only (meters).  Never used as the racer glyph.
 LOOKAHEAD_DISC_R: float = 1.5

--- a/src/arco/simulator/sim/city_race_style.py
+++ b/src/arco/simulator/sim/city_race_style.py
@@ -34,10 +34,14 @@ PLANNED_ROUTE_WIDTH: float = 2.0
 PLANNED_ROUTE_ALPHA: float = 0.35
 
 # Default city-demo prediction horizon when scenario YAML omits an override.
-# 72 × 0.05 s = 3.6 s (~43 m at the soft city cruise of 12 m/s) — about half
-# a city block (mean_edge_length = 120 m).
-DEFAULT_CITY_HORIZON_STEP_COUNT: int = 72
-DEFAULT_CITY_HORIZON_DT: float = 0.05
+# The horizon dt MUST equal the simulator timestep (0.1 s): the MPC's first
+# predicted state is the command target, so a model dt shorter than the
+# control period makes the plant travel twice as far per tick as planned —
+# the historical source of the race zigzag.  50 × 0.1 s = 5.0 s (~60 m at
+# the city cruise of 12 m/s), longer than the 4.8 s full-stop braking time
+# from cruise so corners are always previewed in time.
+DEFAULT_CITY_HORIZON_STEP_COUNT: int = 50
+DEFAULT_CITY_HORIZON_DT: float = 0.1
 
 # Soft but lane-viable city-racer dynamics.  Prior snap limits (ω=60°/s,
 # ω̇≈∞, a=4.9, cruise=18) let the NMPC nail A* kinks then reverse progress.

--- a/src/arco/simulator/sim/tracking.py
+++ b/src/arco/simulator/sim/tracking.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Optional
 if TYPE_CHECKING:
     from arco.mapping.occupancy import Occupancy
 
+from arco.config import load_config
 from arco.control.joint_tracker import JointSpaceTracker
 from arco.control.mpc import (
     DubinsPathFollowingMPC,
@@ -27,6 +28,39 @@ from arco.control.mpc import (
 from arco.control.pure_pursuit import PurePursuitController
 from arco.control.tracking import TrackingLoop
 from arco.guidance.vehicle import DubinsVehicle
+
+# PPP / RRP joint-space MPC defaults when scenario YAML omits overrides.
+# These scenarios use a finer 0.05 s control period than the global
+# simulator.yml timestep (0.1 s); horizon dt MUST match that period.
+DEFAULT_JOINT_HORIZON_STEP_COUNT: int = 12
+DEFAULT_JOINT_HORIZON_DT: float = 0.05
+
+
+def resolve_sim_timestep(
+    cfg: dict[str, Any],
+    *,
+    global_sim_cfg: dict[str, Any] | None = None,
+) -> float:
+    """Return the simulation/control period from scenario or global config.
+
+    Reads ``simulator.timestep`` or legacy ``simulator.dt`` from *cfg*
+    first, then falls back to ``timestep`` in the global ``simulator.yml``.
+
+    Args:
+        cfg: Full scenario configuration dict (e.g. loaded map YAML).
+        global_sim_cfg: Optional pre-loaded global simulator config.
+
+    Returns:
+        Control period in seconds.
+    """
+    sim = cfg.get("simulator", {})
+    if isinstance(sim, dict):
+        if sim.get("timestep") is not None:
+            return float(sim["timestep"])
+        if sim.get("dt") is not None:
+            return float(sim["dt"])
+    global_sim = global_sim_cfg or load_config("simulator")
+    return float(global_sim["timestep"])
 
 
 def path_following_mpc_config_from_simulator(
@@ -111,6 +145,62 @@ def path_following_mpc_config_from_simulator(
                 None
                 if weights.get("contour_deadzone") is None
                 else float(weights["contour_deadzone"])
+            ),
+        )
+    return cfg
+
+
+def joint_space_mpc_config_from_simulator(
+    sim_cfg: dict[str, Any] | None = None,
+    *,
+    default_horizon_step_count: int | None = None,
+    default_horizon_dt: float | None = None,
+) -> JointSpaceMPCConfig:
+    """Build joint-space MPC config from global defaults + scenario YAML.
+
+    Reads optional ``simulator.mpc.horizon.{step_count,dt}`` and
+    ``simulator.mpc.weights.*`` overrides from *sim_cfg*.  When horizon
+    keys are absent, *default_horizon_** values (if provided) replace the
+    global ``mpc.yml`` joint-space horizon.
+
+    Args:
+        sim_cfg: Scenario ``simulator`` dict (may be ``None`` / empty).
+        default_horizon_step_count: Horizon steps when YAML omits
+            ``mpc.horizon.step_count``.
+        default_horizon_dt: Horizon ``dt`` when YAML omits
+            ``mpc.horizon.dt``.
+
+    Returns:
+        Configured :class:`JointSpaceMPCConfig`.
+    """
+    cfg = JointSpaceMPCConfig.create_from_config()
+    sim = sim_cfg if isinstance(sim_cfg, dict) else {}
+    mpc = sim.get("mpc") if isinstance(sim.get("mpc"), dict) else {}
+    horizon = (
+        mpc.get("horizon") if isinstance(mpc.get("horizon"), dict) else {}
+    )
+    weights = (
+        mpc.get("weights") if isinstance(mpc.get("weights"), dict) else {}
+    )
+    step_count = horizon.get("step_count", default_horizon_step_count)
+    dt = horizon.get("dt", default_horizon_dt)
+    if step_count is not None or dt is not None:
+        cfg = cfg.with_horizon_overrides(
+            step_count=None if step_count is None else int(step_count),
+            dt=None if dt is None else float(dt),
+        )
+    if weights:
+        cfg = replace(
+            cfg,
+            weight_tracking=float(
+                weights.get("tracking", cfg.weight_tracking)
+            ),
+            weight_velocity=float(
+                weights.get("velocity", cfg.weight_velocity)
+            ),
+            weight_control=float(weights.get("control", cfg.weight_control)),
+            weight_obstacle=float(
+                weights.get("obstacle", cfg.weight_obstacle)
             ),
         )
     return cfg

--- a/src/arco/simulator/sim/tracking.py
+++ b/src/arco/simulator/sim/tracking.py
@@ -107,11 +107,6 @@ def path_following_mpc_config_from_simulator(
                 if weights.get("terminal") is None
                 else float(weights["terminal"])
             ),
-            slack=(
-                None
-                if weights.get("slack") is None
-                else float(weights["slack"])
-            ),
             contour_deadzone=(
                 None
                 if weights.get("contour_deadzone") is None

--- a/tests/control/mpc/conftest.py
+++ b/tests/control/mpc/conftest.py
@@ -46,7 +46,9 @@ class RectOccupancy(Occupancy):
             dist_right = self.x_max - pt[0]
             dist_bottom = pt[1] - self.y_min
             dist_top = self.y_max - pt[1]
-            side = int(np.argmin([dist_left, dist_right, dist_bottom, dist_top]))
+            side = int(
+                np.argmin([dist_left, dist_right, dist_bottom, dist_top])
+            )
             if side == 0:
                 nearest = np.array([self.x_min, pt[1]], dtype=float)
             elif side == 1:

--- a/tests/control/mpc/test_joint_space_mpc.py
+++ b/tests/control/mpc/test_joint_space_mpc.py
@@ -54,6 +54,18 @@ def test_joint_space_mpc_avoids_box() -> None:
     assert min_clearance >= 0.8 * occ.clearance
 
 
+def test_joint_space_mpc_rejects_dt_mismatch() -> None:
+    cfg = JointSpaceMPCConfig(horizon_step_count=8, dt=0.05)
+    mpc = JointSpaceMPC(
+        max_vel=np.array([1.0, 1.0]),
+        max_acc=np.array([2.0, 2.0]),
+        config=cfg,
+    )
+    mpc.reset(np.zeros(2))
+    with pytest.raises(ValueError, match="config.dt"):
+        mpc.step(np.array([0.5, 0.0]), dt=0.1)
+
+
 def test_build_joint_tracker_mpc_factory() -> None:
     from arco.simulator.sim.tracking import build_joint_tracker
 

--- a/tests/control/mpc/test_path_following_mpc.py
+++ b/tests/control/mpc/test_path_following_mpc.py
@@ -247,6 +247,8 @@ def test_path_following_config_from_yaml() -> None:
     assert abs(cfg.dt - 0.05) < 1e-12
     assert abs(cfg.cruise_speed - 0.42) < 1e-12
     assert cfg.weight_obstacle > 0.0
+    # Lag is structural in the MPCC formulation — must default positive.
+    assert cfg.weight_lag > 0.0
 
 
 def test_path_following_config_with_horizon_overrides() -> None:
@@ -274,8 +276,15 @@ def test_path_following_config_with_weight_overrides() -> None:
     assert abs(soft.contour_deadzone - 8.0) < 1e-12
     assert soft.horizon_step_count == cfg.horizon_step_count
     assert abs(cfg.weight_contour - 10.0) < 1e-12
-    assert abs(cfg.weight_lag) < 1e-12
+    assert cfg.weight_lag > 0.0
     assert abs(cfg.contour_deadzone) < 1e-12
+
+
+def test_zero_lag_weight_is_rejected() -> None:
+    """weight_lag = 0 decouples the virtual progress → invalid MPCC."""
+    cfg = _cfg(weight_lag=0.0)
+    with pytest.raises(ValueError):
+        DubinsPathFollowingMPC(vehicle_limits=_limits(), config=cfg)
 
 
 def test_mpc_progress_does_not_reverse_when_heading_error_is_large() -> None:
@@ -320,12 +329,12 @@ def test_mpc_progress_does_not_reverse_when_heading_error_is_large() -> None:
     assert progress_values[-1] >= progress_values[0] - 1e-3
 
 
-def test_mpc_progress_first_accepts_lateral_slip_to_advance() -> None:
-    """Lag + deadzone prefer advancing s over hugging a sharp kink.
+def test_mpc_progress_advances_through_sharp_corner() -> None:
+    """The MPCC keeps s advancing through a corner infeasible at cruise.
 
-    On a right-angle path with limited turn rate, progress-first weights
-    should keep arc-length increasing even while |e_lat| stays inside /
-    near the free band — the opposite of stiff contouring that stalls.
+    On a right-angle path with limited turn rate, the virtual-progress /
+    lag split must keep arc-length increasing (no stall or orbit) while
+    lateral error stays inside the road-scale free band.
     """
     path = [(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (4.0, 8.0)]
     cfg = _cfg(
@@ -369,8 +378,9 @@ def test_mpc_progress_first_accepts_lateral_slip_to_advance() -> None:
         vehicle.step(result.speed_cmd, result.turn_rate_cmd, dt)
 
     assert progresses[-1] > progresses[0] + 2.0
-    # Must have used some of the free band / allowed slip near the corner.
-    assert max_abs_lat > 0.15
+    # Corner negotiated by braking + tight tracking: slip stays inside the
+    # free band instead of exceeding it.
+    assert max_abs_lat < 2.0 * 0.8
 
 
 def test_mpc_lane_aware_corner_stays_inside_road_budget() -> None:
@@ -467,16 +477,16 @@ def test_mpc_city_horizon_solves_dense_astar_style_kinks() -> None:
 
     cfg = _cfg(
         cruise_speed=12.0,
-        weight_contour=8.0,
-        weight_heading=4.0,
-        weight_progress=4.0,
-        weight_lag=4.0,
-        contour_deadzone=2.5,
-        weight_control=0.5,
+        weight_contour=10.0,
+        weight_heading=1.0,
+        weight_progress=8.0,
+        weight_lag=6.0,
+        contour_deadzone=0.0,
+        weight_control=0.3,
         weight_obstacle=0.0,
         weight_terminal=8.0,
-        horizon_step_count=72,
-        dt=0.05,
+        horizon_step_count=50,
+        dt=0.1,
         max_solver_iter_count=80,
     )
     limits = _limits(
@@ -501,7 +511,8 @@ def test_mpc_city_horizon_solves_dense_astar_style_kinks() -> None:
     # Match race start: vehicle begins at rest.
     vehicle._speed = 0.0
 
-    dt = 0.1
+    # Control period equals the model dt (the corrected city wiring).
+    dt = cfg.dt
     success_count = 0
     for _ in range(25):
         result = mpc.step(
@@ -517,4 +528,3 @@ def test_mpc_city_horizon_solves_dense_astar_style_kinks() -> None:
     assert success_count >= 20
     assert vehicle.speed > 1.0
     assert math.hypot(vehicle.x - path[0][0], vehicle.y - path[0][1]) > 2.0
-

--- a/tests/control/mpc/test_path_following_mpc.py
+++ b/tests/control/mpc/test_path_following_mpc.py
@@ -244,7 +244,7 @@ def test_mpc_solver_failure_safe_stop(straight_path) -> None:
 def test_path_following_config_from_yaml() -> None:
     cfg = PathFollowingMPCConfig.create_from_config(cruise_speed=0.42)
     assert cfg.horizon_step_count == 20
-    assert abs(cfg.dt - 0.05) < 1e-12
+    assert abs(cfg.dt - 0.1) < 1e-12
     assert abs(cfg.cruise_speed - 0.42) < 1e-12
     assert cfg.weight_obstacle > 0.0
     # Lag is structural in the MPCC formulation — must default positive.

--- a/tests/control/mpc/test_reference_path.py
+++ b/tests/control/mpc/test_reference_path.py
@@ -63,14 +63,27 @@ def test_reference_path_curvature_detects_sharp_l_kink() -> None:
     The previous skip-one finite difference reported κ≈0 at the vertex of
     ``(0,0)→(50,0)→(50,50)`` because ``h[i-1]`` and ``h[i+1]`` cancelled.
     """
-    path = ReferencePath([(0.0, 0.0), (50.0, 0.0), (50.0, 50.0)])
+    path = ReferencePath(
+        [
+            (0.0, 0.0),
+            (10.0, 0.0),
+            (20.0, 0.0),
+            (30.0, 0.0),
+            (40.0, 0.0),
+            (50.0, 0.0),
+            (50.0, 50.0),
+        ]
+    )
     kappa_corner = abs(path.curvature(50.0))
     # Spread over ds_cap=20 m → |κ| = (π/2) / 20 ≈ 0.0785.
     assert kappa_corner > 0.05
-    # Approach preview must expose the corner κ well before the vertex so
-    # the NMPC can decelerate (city soft a_max needs tens of meters).
-    kappa_approach = abs(path.curvature(20.0))
+    # A short approach preview keeps the corner κ visible just before the
+    # vertex; longer-range braking is planned by the MPCC horizon itself.
+    kappa_approach = abs(path.curvature(40.0))
     assert kappa_approach > 0.05
+    # Far from the corner, κ must relax back to ~0 so cruise is not
+    # dragged down along the whole straight.
+    assert abs(path.curvature(20.0)) < 0.01
 
 
 def test_reference_path_curvature_grid_corner_limits_city_speed() -> None:

--- a/tests/control/mpc/test_tracking_loop.py
+++ b/tests/control/mpc/test_tracking_loop.py
@@ -107,14 +107,16 @@ def test_build_vehicle_mpc_sim_preserves_progress_first_weights() -> None:
         max_acceleration=2.5,
         max_turn_rate_dot=math.radians(90.0),
     )
-    mpc_cfg = PathFollowingMPCConfig.create_from_config().with_weight_overrides(
-        contour=8.0,
-        heading=4.0,
-        progress=4.0,
-        lag=4.0,
-        control=0.5,
-        obstacle=120.0,
-        contour_deadzone=0.0,
+    mpc_cfg = (
+        PathFollowingMPCConfig.create_from_config().with_weight_overrides(
+            contour=8.0,
+            heading=4.0,
+            progress=4.0,
+            lag=4.0,
+            control=0.5,
+            obstacle=120.0,
+            contour_deadzone=0.0,
+        )
     )
     _vehicle, loop = build_vehicle_mpc_sim(path, cfg, mpc_cfg)
     live = loop.tracker.config

--- a/tests/guidance/test_moving_average.py
+++ b/tests/guidance/test_moving_average.py
@@ -1,0 +1,59 @@
+"""Tests for MovingAverageInterpolator polyline smoothing."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from arco.guidance.interpolation import MovingAverageInterpolator
+
+
+def _wiggle_amplitude(path: list[tuple[float, float]]) -> float:
+    """Max mid-region |y| of a nominally straight (y = 0) path.
+
+    The three points nearest each end are excluded: endpoints are
+    preserved exactly and pin their neighbors' amplitude.
+    """
+    return max(abs(p[1]) for p in path[3:-3])
+
+
+def test_endpoints_are_preserved() -> None:
+    path = [(0.0, 0.0), (1.0, 2.0), (2.0, -2.0), (3.0, 0.5), (4.0, 0.0)]
+    smoothed = MovingAverageInterpolator(iterations=3).interpolate(path)
+    assert smoothed[0] == path[0]
+    assert smoothed[-1] == path[-1]
+    assert len(smoothed) == len(path)
+
+
+def test_reduces_lateral_wiggle() -> None:
+    # Zigzag around the x-axis: amplitude must shrink monotonically.
+    path = [(float(i), (1.0 if i % 2 else -1.0)) for i in range(12)]
+    one = MovingAverageInterpolator(iterations=1).interpolate(path)
+    three = MovingAverageInterpolator(iterations=3).interpolate(path)
+    assert _wiggle_amplitude(one) < _wiggle_amplitude(path)
+    assert _wiggle_amplitude(three) < _wiggle_amplitude(one)
+
+
+def test_straight_line_is_unchanged() -> None:
+    path = [(float(i), 0.0) for i in range(8)]
+    smoothed = MovingAverageInterpolator(iterations=2).interpolate(path)
+    for (x0, y0), (x1, y1) in zip(path, smoothed):
+        assert math.isclose(x0, x1, abs_tol=1e-12)
+        assert math.isclose(y0, y1, abs_tol=1e-12)
+
+
+def test_short_paths_pass_through() -> None:
+    assert MovingAverageInterpolator().interpolate([]) == []
+    assert MovingAverageInterpolator().interpolate([(1.0, 2.0)]) == [
+        (1.0, 2.0)
+    ]
+    two = [(0.0, 0.0), (1.0, 1.0)]
+    assert MovingAverageInterpolator().interpolate(two) == two
+
+
+def test_invalid_window_rejected() -> None:
+    with pytest.raises(ValueError):
+        MovingAverageInterpolator(window=2)
+    with pytest.raises(ValueError):
+        MovingAverageInterpolator(window=1)

--- a/tests/simulator/sim/test_car_sprite.py
+++ b/tests/simulator/sim/test_car_sprite.py
@@ -1,0 +1,76 @@
+"""Tests for the GTA2-style car sprite surface generation."""
+
+from __future__ import annotations
+
+import pytest
+
+pygame = pytest.importorskip("pygame")
+pytest.importorskip("OpenGL")
+
+from arco.simulator.sim.car_sprite import (  # noqa: E402
+    _GRID_L,
+    _GRID_W,
+    make_car_sprite_surface,
+)
+
+_BLUE = (59, 130, 246)
+_GREEN = (34, 197, 94)
+
+
+def _logical(surf: pygame.Surface, x: int, y: int, scale: int = 4):
+    """Sample the center of logical pixel (x, y) of an upscaled sprite."""
+    return surf.get_at((x * scale + scale // 2, y * scale + scale // 2))
+
+
+def test_sprite_surface_size_and_alpha() -> None:
+    surf = make_car_sprite_surface(_BLUE)
+    assert surf.get_size() == (_GRID_L * 4, _GRID_W * 4)
+    # Sprite corners are transparent (rounded body, no full-rect blob).
+    assert _logical(surf, 0, 0).a == 0
+    assert _logical(surf, _GRID_L - 1, _GRID_W - 1).a == 0
+
+
+def test_sprite_has_tires_glass_and_lights() -> None:
+    surf = make_car_sprite_surface(_BLUE)
+    # Tires: near-black pixels poking out on the sides.
+    tire = _logical(surf, 4, 0)
+    assert tire.a == 255
+    assert max(tire.r, tire.g, tire.b) < 60
+    # Windshield glass is a desaturated dark blue-gray, not body blue.
+    glass = _logical(surf, 14, 5)
+    assert glass.b > glass.r
+    assert max(glass.r, glass.g, glass.b) < 160
+    # Headlights (front, +X) are pale yellow; taillights are red.
+    head = _logical(surf, 22, 3)
+    assert head.r > 200 and head.g > 200
+    tail = _logical(surf, 1, 3)
+    assert tail.r > 150 and tail.g < 90
+
+
+def test_sprite_body_uses_racer_color() -> None:
+    blue = make_car_sprite_surface(_BLUE)
+    green = make_car_sprite_surface(_GREEN)
+    body_blue = _logical(blue, 18, 5)
+    body_green = _logical(green, 18, 5)
+    # Hue follows the racer color (blue-dominant vs green-dominant).
+    assert body_blue.b > body_blue.g > body_blue.r
+    assert body_green.g > body_green.r
+    assert body_green.g > body_green.b
+    # Distinct racer colors must yield distinct sprites.
+    assert (body_blue.r, body_blue.g, body_blue.b) != (
+        body_green.r,
+        body_green.g,
+        body_green.b,
+    )
+
+
+def test_sprite_roof_is_lighter_than_sides() -> None:
+    surf = make_car_sprite_surface(_BLUE)
+    roof = _logical(surf, 10, 5)
+    side = _logical(surf, 10, 2)
+    assert (roof.r + roof.g + roof.b) > (side.r + side.g + side.b)
+
+
+def test_sprite_custom_scale() -> None:
+    surf = make_car_sprite_surface(_BLUE, scale=2)
+    assert surf.get_size() == (_GRID_L * 2, _GRID_W * 2)

--- a/tests/simulator/sim/test_city_race_style.py
+++ b/tests/simulator/sim/test_city_race_style.py
@@ -33,10 +33,13 @@ from arco.simulator.sim.tracking import (
 
 
 def test_city_race_vehicle_is_visible_rectangle() -> None:
-    # Prior city glyph was 3.0 × 1.4 m; keep a clearly larger rectangle, not
-    # a disc-based racer glyph.
-    assert VEH_HALF_L == 8.0
-    assert VEH_HALF_W == 3.6
+    # Visible car glyph (12 × 5.4 m), but small enough that the sprite's
+    # nose cannot sweep over inner-corner buildings on routes that pass
+    # ~7.7 m from them: tip reach (half-length) must stay well below the
+    # minimum legitimate center clearance.
+    assert VEH_HALF_L == 6.0
+    assert VEH_HALF_W == 2.7
+    assert VEH_HALF_L <= 7.0
     # Lookahead disc is only a small PP carrot, never the vehicle body.
     assert LOOKAHEAD_DISC_R <= 2.0
     assert LOOKAHEAD_DISC_R < min(VEH_HALF_L, VEH_HALF_W)

--- a/tests/simulator/sim/test_city_race_style.py
+++ b/tests/simulator/sim/test_city_race_style.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import yaml
 
+from arco.config import load_config
 from arco.control.mpc import PathFollowingMPCConfig
 from arco.simulator.sim.city_race_style import (
     CITY_CRUISE_SPEED,
@@ -50,26 +51,20 @@ def test_city_race_traces_are_thicker_and_prediction_visible() -> None:
     assert 0.0 < PLANNED_ROUTE_ALPHA < 0.6
 
 
-def test_city_default_horizon_is_half_block() -> None:
-    """City horizon is 60% of the prior 6.0 s / 120-step setting.
+def test_city_default_horizon_matches_simulator_timestep() -> None:
+    """City MPC model dt must equal the 0.1 s simulator timestep.
 
-    72 × 0.05 s = 3.6 s ≈ half of ``mean_edge_length`` (120 m) at soft cruise.
+    The MPC's first predicted state is the command target; a model dt
+    shorter than the control period makes the plant travel further per
+    tick than planned (the historical race zigzag).  40 × 0.1 s = 4.0 s
+    of preview (~48 m at 12 m/s cruise) covers corner braking distance.
     """
-    assert DEFAULT_CITY_HORIZON_STEP_COUNT == 72
-    assert abs(DEFAULT_CITY_HORIZON_DT - 0.05) < 1e-12
-    assert (
-        abs(DEFAULT_CITY_HORIZON_STEP_COUNT * DEFAULT_CITY_HORIZON_DT - 3.6)
-        < 1e-12
-    )
-    # Explicitly 60% of the previous full-block horizon (120 steps / 6.0 s).
-    assert DEFAULT_CITY_HORIZON_STEP_COUNT == int(120 * 0.6)
-    assert (
-        abs(
-            DEFAULT_CITY_HORIZON_STEP_COUNT * DEFAULT_CITY_HORIZON_DT
-            - 6.0 * 0.6
-        )
-        < 1e-12
-    )
+    sim_cfg = load_config("simulator")
+    assert abs(DEFAULT_CITY_HORIZON_DT - float(sim_cfg["timestep"])) < 1e-12
+    assert DEFAULT_CITY_HORIZON_STEP_COUNT == 50
+    # Preview must exceed the full-stop braking time from cruise.
+    preview_s = DEFAULT_CITY_HORIZON_STEP_COUNT * DEFAULT_CITY_HORIZON_DT
+    assert preview_s > CITY_CRUISE_SPEED / CITY_MAX_ACCELERATION
 
 
 def test_city_vehicle_dynamics_are_soft_but_lane_viable() -> None:
@@ -106,8 +101,8 @@ def test_path_following_mpc_config_uses_city_defaults_without_yaml() -> None:
         default_horizon_step_count=DEFAULT_CITY_HORIZON_STEP_COUNT,
         default_horizon_dt=DEFAULT_CITY_HORIZON_DT,
     )
-    assert city_cfg.horizon_step_count == 72
-    assert abs(city_cfg.dt - 0.05) < 1e-12
+    assert city_cfg.horizon_step_count == 50
+    assert abs(city_cfg.dt - 0.1) < 1e-12
 
 
 def test_path_following_mpc_config_honors_yaml_override() -> None:
@@ -150,23 +145,27 @@ def test_path_following_mpc_config_honors_weight_overrides() -> None:
     assert abs(cfg.contour_deadzone) < 1e-12
 
 
-def test_city_map_yaml_declares_progress_first_zero_deadzone() -> None:
-    """City YAML keeps lag/progress but no flat lateral cost band."""
+def test_city_map_yaml_declares_mpcc_tuning() -> None:
+    """City YAML: horizon dt == sim timestep, MPCC weights sane."""
     root = Path(__file__).resolve().parents[3]
+    sim_cfg = load_config("simulator")
     for name in ("city.yml", "city_mpc_preview.yml"):
         data = yaml.safe_load((root / "map" / name).read_text())
         horizon = data["simulator"]["mpc"]["horizon"]
-        assert int(horizon["step_count"]) == 72
-        assert (
-            abs(float(horizon["dt"]) * int(horizon["step_count"]) - 3.6)
-            < 1e-12
-        )
+        # Model step must match the closed-loop control period.
+        assert abs(float(horizon["dt"]) - float(sim_cfg["timestep"])) < 1e-12
+        # Enough preview to brake from cruise before a sharp corner.
+        preview_s = float(horizon["dt"]) * int(horizon["step_count"])
+        braking_s = CITY_CRUISE_SPEED / CITY_MAX_ACCELERATION
+        assert preview_s > braking_s
         weights = data["simulator"]["mpc"]["weights"]
-        # Contour must dominate wall-seeking freedom; lag still advances s.
-        assert float(weights["contour"]) >= 6.0
-        assert float(weights["heading"]) >= 3.0
-        assert float(weights["lag"]) >= 2.0
-        assert float(weights["lag"]) <= 6.0
+        # Contour dominates; lag is structural (couples s to the vehicle).
+        assert float(weights["contour"]) >= 8.0
+        assert float(weights["lag"]) >= 4.0
+        assert float(weights["progress"]) > 0.0
+        # Heading stays a light alignment term (tracking emerges from
+        # contour + lag; heavy heading tracking fights kinked references).
+        assert float(weights["heading"]) <= 2.0
         # Flat |e_lat| bands zero the lateral gradient → equal-cost chatter.
         assert abs(float(weights["contour_deadzone"])) < 1e-12
         assert float(weights["obstacle"]) >= 100.0

--- a/tests/simulator/sim/test_joint_mpc_horizon.py
+++ b/tests/simulator/sim/test_joint_mpc_horizon.py
@@ -1,0 +1,75 @@
+"""Joint-space MPC horizon must match scenario control period (PPP / RRP)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from arco.config import load_config
+from arco.simulator.sim.tracking import (
+    DEFAULT_JOINT_HORIZON_DT,
+    DEFAULT_JOINT_HORIZON_STEP_COUNT,
+    joint_space_mpc_config_from_simulator,
+    resolve_sim_timestep,
+)
+
+
+def test_joint_default_horizon_matches_ppp_timestep() -> None:
+    """PPP uses 0.05 s steps; joint MPC model dt must match."""
+    global_sim = load_config("simulator")
+    ppp = yaml.safe_load(Path("map/ppp.yml").read_text(encoding="utf-8"))
+    dt = resolve_sim_timestep(ppp, global_sim_cfg=global_sim)
+    assert abs(dt - DEFAULT_JOINT_HORIZON_DT) < 1e-12
+    assert DEFAULT_JOINT_HORIZON_STEP_COUNT == 12
+
+    mpc_cfg = joint_space_mpc_config_from_simulator(
+        ppp.get("simulator", {}),
+        default_horizon_step_count=DEFAULT_JOINT_HORIZON_STEP_COUNT,
+        default_horizon_dt=dt,
+    )
+    assert abs(mpc_cfg.dt - dt) < 1e-12
+    assert mpc_cfg.horizon_step_count == 12
+
+
+def test_joint_default_horizon_matches_rrp_timestep() -> None:
+    """RRP uses the same 0.05 s control period as PPP."""
+    global_sim = load_config("simulator")
+    rrp = yaml.safe_load(Path("map/rrp.yml").read_text(encoding="utf-8"))
+    dt = resolve_sim_timestep(rrp, global_sim_cfg=global_sim)
+    assert abs(dt - 0.05) < 1e-12
+
+    mpc_cfg = joint_space_mpc_config_from_simulator(
+        rrp.get("simulator", {}),
+        default_horizon_step_count=DEFAULT_JOINT_HORIZON_STEP_COUNT,
+        default_horizon_dt=dt,
+    )
+    assert abs(mpc_cfg.dt - dt) < 1e-12
+
+
+def test_map_yaml_joint_mpc_horizon_matches_timestep() -> None:
+    """Scenario YAML must declare mpc.horizon.dt == simulator.timestep."""
+    global_sim = load_config("simulator")
+    for name in ("ppp.yml", "rrp.yml"):
+        data = yaml.safe_load(Path(f"map/{name}").read_text(encoding="utf-8"))
+        sim = data["simulator"]
+        dt = resolve_sim_timestep(data, global_sim_cfg=global_sim)
+        horizon = sim["mpc"]["horizon"]
+        assert abs(float(horizon["dt"]) - dt) < 1e-12
+        assert int(horizon["step_count"]) > 0
+
+
+def test_resolve_sim_timestep_falls_back_to_global() -> None:
+    """Scenarios without an override use simulator.yml timestep."""
+    global_sim = load_config("simulator")
+    city = yaml.safe_load(Path("map/city.yml").read_text(encoding="utf-8"))
+    dt = resolve_sim_timestep(city, global_sim_cfg=global_sim)
+    assert abs(dt - float(global_sim["timestep"])) < 1e-12
+
+
+def test_occ_timestep_matches_global() -> None:
+    """OCC has no MPC but should resolve the global 0.1 s period."""
+    global_sim = load_config("simulator")
+    occ = yaml.safe_load(Path("map/occ.yml").read_text(encoding="utf-8"))
+    dt = resolve_sim_timestep(occ, global_sim_cfg=global_sim)
+    assert abs(dt - float(global_sim["timestep"])) < 1e-12

--- a/tests/simulator/sim/test_reference_smoothing.py
+++ b/tests/simulator/sim/test_reference_smoothing.py
@@ -1,0 +1,63 @@
+"""Tests for the clearance-guarded reference smoothing in CityScene."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pygame = pytest.importorskip("pygame")
+pytest.importorskip("OpenGL")
+
+from arco.simulator.scenes.sparse import (  # noqa: E402
+    _min_polyline_clearance,
+    _smooth_reference,
+)
+
+
+class _PointOccupancy:
+    """Minimal occupancy stub with a fixed obstacle point set."""
+
+    def __init__(self, points: list[tuple[float, float]]) -> None:
+        self._points = np.asarray(points, dtype=float)
+
+    def nearest_obstacle(self, point: np.ndarray) -> tuple[float, np.ndarray]:
+        dists = np.linalg.norm(self._points - point[None, :2], axis=1)
+        i = int(np.argmin(dists))
+        return float(dists[i]), self._points[i]
+
+
+def test_smoothing_removes_wiggle_when_clearance_safe() -> None:
+    # Wiggly path far away from the single obstacle: smoothing accepted.
+    occ = _PointOccupancy([(0.0, 100.0)])
+    path = [(float(i), (0.8 if i % 2 else -0.8)) for i in range(12)]
+    smoothed = _smooth_reference(path, occ)
+    interior = smoothed[1:-1]
+    assert max(abs(p[1]) for p in interior) < 0.8
+    assert smoothed[0] == path[0]
+    assert smoothed[-1] == path[-1]
+
+
+def test_smoothing_reverted_when_it_cuts_toward_obstacle() -> None:
+    # Sharp corner with an obstacle hugging the inside: the moving
+    # average would cut toward it, so the guard must return the original.
+    occ = _PointOccupancy([(8.5, 1.5)])
+    path = [
+        (0.0, 0.0),
+        (5.0, 0.0),
+        (10.0, 0.0),
+        (10.0, 5.0),
+        (10.0, 10.0),
+    ]
+    result = _smooth_reference(path, occ)
+    assert result == path
+
+
+def test_min_polyline_clearance_samples_between_waypoints() -> None:
+    occ = _PointOccupancy([(5.0, 1.0)])
+    # No waypoint is near the obstacle, but the segment midpoint is.
+    path = [(0.0, 0.0), (10.0, 0.0)]
+    clearance = _min_polyline_clearance(path, occ, sample_spacing=1.0)
+    assert clearance == pytest.approx(1.0, abs=0.2)
+    # Endpoint-only evaluation would report ≥ 5 m — sampling must see
+    # the mid-segment pinch.
+    assert clearance < 2.0

--- a/tools/city_tracking_report.py
+++ b/tools/city_tracking_report.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python
+"""Headless closed-loop tracking report for the city race scenario.
+
+Rebuilds the exact ``map/city*.yml`` scenario (world, planners, optimizer)
+without any OpenGL window, runs the same MPC tracking loops the recorded
+race uses, and reports per-racer quality metrics:
+
+* finish time (or timeout),
+* mean / max absolute cross-track error,
+* minimum clearance to the building point cloud (collision gate),
+* solver failure count.
+
+A matplotlib overview image (map + executed trajectories) is written next
+to the report so tracking quality can be inspected visually without
+recording a full video.
+
+Usage
+-----
+::
+
+    python tools/city_tracking_report.py                       # preview map
+    python tools/city_tracking_report.py --map map/city.yml    # full budgets
+    python tools/city_tracking_report.py --out /tmp/report.png
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import yaml
+
+from arco.simulator.scenes.sparse import CityScene
+from arco.simulator.sim.city_race_style import (
+    DEFAULT_CITY_HORIZON_DT,
+    DEFAULT_CITY_HORIZON_STEP_COUNT,
+    VEH_HALF_L,
+    VEH_HALF_W,
+)
+from arco.simulator.sim.tracking import (
+    build_vehicle_mpc_sim,
+    build_vehicle_sim,
+    path_following_mpc_config_from_simulator,
+)
+
+# Simulation timestep — matches src/arco/config/simulator.yml.
+_SIM_DT = 0.1
+# Wall-clock cap per racer (simulated seconds).
+_TIMEOUT_S = 150.0
+# Extra margin (m) around the rendered vehicle rectangle when testing
+# building-point overlap (accounts for the drawn point size).
+_FOOTPRINT_MARGIN_M = 0.5
+
+
+def _footprint_overlap(
+    x: float,
+    y: float,
+    heading: float,
+    obstacle_xy: np.ndarray,
+) -> bool:
+    """Whether an obstacle point lies inside the rendered car rectangle.
+
+    Args:
+        x: Vehicle center x (m).
+        y: Vehicle center y (m).
+        heading: Vehicle heading (rad).
+        obstacle_xy: Nearest obstacle point ``[x, y]``.
+
+    Returns:
+        ``True`` when the point falls inside the oriented glyph footprint
+        (plus :data:`_FOOTPRINT_MARGIN_M`), i.e. a visual collision.
+    """
+    dx = float(obstacle_xy[0]) - x
+    dy = float(obstacle_xy[1]) - y
+    cos_h = math.cos(heading)
+    sin_h = math.sin(heading)
+    lx = dx * cos_h + dy * sin_h
+    ly = -dx * sin_h + dy * cos_h
+    return (
+        abs(lx) <= VEH_HALF_L + _FOOTPRINT_MARGIN_M
+        and abs(ly) <= VEH_HALF_W + _FOOTPRINT_MARGIN_M
+    )
+
+
+@dataclass
+class RacerReport:
+    """Aggregated closed-loop metrics for one racer.
+
+    Attributes:
+        name: Planner name (``RRT*`` / ``SST`` / ``A*``).
+        finish_time: Simulated seconds to reach the goal, ``None`` on timeout.
+        max_abs_lat: Maximum absolute cross-track error (m).
+        mean_abs_lat: Mean absolute cross-track error (m).
+        min_clearance: Minimum distance to the building point cloud (m).
+        solver_failures: Number of failed MPC solves.
+        steps: Number of executed simulation steps.
+        trajectory: Executed ``(x, y)`` positions.
+        collision_count: Steps with a building point inside the rendered
+            vehicle footprint.
+    """
+
+    name: str
+    finish_time: float | None = None
+    max_abs_lat: float = 0.0
+    mean_abs_lat: float = 0.0
+    min_clearance: float = float("inf")
+    solver_failures: int = 0
+    steps: int = 0
+    trajectory: list[tuple[float, float]] = field(default_factory=list)
+    collision_count: int = 0
+
+    @property
+    def collided(self) -> bool:
+        """Whether the racer visually clipped a building."""
+        return self.collision_count > 0
+
+
+def _run_racer(
+    name: str,
+    waypoints: list[tuple[float, float]],
+    scene: CityScene,
+    tracker_mode: str,
+) -> RacerReport:
+    """Run one racer's closed loop to the goal and collect metrics.
+
+    Args:
+        name: Display name for the report.
+        waypoints: Optimized reference waypoints from the scene.
+        scene: Built city scene (provides occupancy + vehicle config).
+        tracker_mode: ``"mpc"`` or ``"pure_pursuit"``.
+
+    Returns:
+        Populated :class:`RacerReport`.
+    """
+    report = RacerReport(name=name)
+    if not waypoints:
+        return report
+    cfg = scene.vehicle_config
+    occ = scene._occ
+    if tracker_mode == "mpc":
+        mpc_cfg = path_following_mpc_config_from_simulator(
+            scene._sim_cfg,
+            default_horizon_step_count=DEFAULT_CITY_HORIZON_STEP_COUNT,
+            default_horizon_dt=DEFAULT_CITY_HORIZON_DT,
+        )
+        vehicle, loop = build_vehicle_mpc_sim(waypoints, cfg, mpc_cfg, occ)
+    else:
+        vehicle, loop = build_vehicle_sim(waypoints, cfg, occ)
+
+    gx, gy = waypoints[-1]
+    abs_lats: list[float] = []
+    t = 0.0
+    while t < _TIMEOUT_S:
+        metrics = loop.step(waypoints, dt=_SIM_DT)
+        t += _SIM_DT
+        report.steps += 1
+        report.trajectory.append((vehicle.x, vehicle.y))
+        lat = abs(float(metrics.get("cross_track_error", 0.0)))
+        abs_lats.append(lat)
+        report.max_abs_lat = max(report.max_abs_lat, lat)
+        if metrics.get("mpc_solver_success") is False:
+            report.solver_failures += 1
+        dist, nearest = occ.nearest_obstacle(
+            np.array([vehicle.x, vehicle.y], dtype=float)
+        )
+        report.min_clearance = min(report.min_clearance, float(dist))
+        if _footprint_overlap(vehicle.x, vehicle.y, vehicle.heading, nearest):
+            report.collision_count += 1
+        if math.hypot(vehicle.x - gx, vehicle.y - gy) < cfg.goal_radius:
+            report.finish_time = t
+            break
+    report.mean_abs_lat = float(np.mean(abs_lats)) if abs_lats else 0.0
+    return report
+
+
+def _save_overview(
+    scene: CityScene, reports: list[RacerReport], out_path: str
+) -> None:
+    """Save a map + executed-trajectory overview image.
+
+    Args:
+        scene: Built city scene.
+        reports: Per-racer reports with executed trajectories.
+        out_path: PNG output path.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(10, 10))
+    pts = np.asarray(scene._occ.points)
+    ax.scatter(pts[:, 0], pts[:, 1], s=1.0, c="#666666", label="buildings")
+    colors = {"RRT*": "#3b82f6", "SST": "#22c55e", "A*": "#a855f7"}
+    refs = {
+        "RRT*": scene.rrt_waypoints,
+        "SST": scene.sst_waypoints,
+        "A*": scene.astar_waypoints,
+    }
+    for rep in reports:
+        color = colors.get(rep.name, "#ffffff")
+        ref = refs.get(rep.name) or []
+        if ref:
+            rx = [p[0] for p in ref]
+            ry = [p[1] for p in ref]
+            ax.plot(rx, ry, color=color, lw=0.8, alpha=0.35)
+        if rep.trajectory:
+            tx = [p[0] for p in rep.trajectory]
+            ty = [p[1] for p in rep.trajectory]
+            ax.plot(tx, ty, color=color, lw=1.8, label=f"{rep.name} executed")
+    ax.set_aspect("equal")
+    ax.legend(loc="upper right", fontsize=8)
+    ax.set_title("City race — executed trajectories vs references")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point.
+
+    Args:
+        argv: Optional CLI argument list (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Process exit code: 0 when every racer finishes with no collision.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--map", default="map/city_mpc_preview.yml", help="Scenario YAML"
+    )
+    parser.add_argument(
+        "--out", default="/tmp/city_tracking_report.png", help="Overview PNG"
+    )
+    args = parser.parse_args(argv)
+
+    with open(args.map, "r", encoding="utf-8") as fh:
+        cfg = yaml.safe_load(fh)
+
+    scene = CityScene(
+        cfg.get("planner", {}),
+        cfg.get("world", {}),
+        sim_cfg=cfg.get("simulator", {}),
+    )
+    t0 = time.perf_counter()
+    scene.build()
+    print(f"Scene built in {time.perf_counter() - t0:.1f} s")
+
+    tracker_mode = str(cfg.get("simulator", {}).get("tracker", "pure_pursuit"))
+    reports: list[RacerReport] = []
+    for name, wps in (
+        ("RRT*", scene.rrt_waypoints),
+        ("SST", scene.sst_waypoints),
+        ("A*", scene.astar_waypoints),
+    ):
+        t0 = time.perf_counter()
+        rep = _run_racer(name, wps, scene, tracker_mode)
+        wall = time.perf_counter() - t0
+        reports.append(rep)
+        finish = (
+            f"{rep.finish_time:.1f} s"
+            if rep.finish_time is not None
+            else "TIMEOUT"
+        )
+        print(
+            f"{name:5s} finish={finish:>9s}  "
+            f"lat(mean/max)={rep.mean_abs_lat:.2f}/{rep.max_abs_lat:.2f} m  "
+            f"min_clear={rep.min_clearance:.2f} m  "
+            f"fails={rep.solver_failures}/{rep.steps}  "
+            f"wall={wall:.1f} s  "
+            f"{'COLLISION x' + str(rep.collision_count) if rep.collided else 'clean'}"
+        )
+
+    _save_overview(scene, reports, args.out)
+    print(f"Overview image: {args.out}")
+
+    ok = all(
+        (r.finish_time is not None) and not r.collided
+        for r in reports
+        if r.steps > 0
+    )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/city_tracking_report.py
+++ b/tools/city_tracking_report.py
@@ -34,6 +34,7 @@ from typing import Any
 
 import numpy as np
 import yaml
+from scipy.spatial import cKDTree
 
 from arco.simulator.scenes.sparse import CityScene
 from arco.simulator.sim.city_race_style import (
@@ -61,30 +62,43 @@ def _footprint_overlap(
     x: float,
     y: float,
     heading: float,
-    obstacle_xy: np.ndarray,
+    kdtree: cKDTree,
+    points: np.ndarray,
 ) -> bool:
-    """Whether an obstacle point lies inside the rendered car rectangle.
+    """Whether any building point lies inside the rendered car rectangle.
+
+    Tests **every** point within the footprint circumradius, not just the
+    Euclidean-nearest one — the nearest point can sit off the car's side
+    while a slightly farther point overlaps the long nose.
 
     Args:
         x: Vehicle center x (m).
         y: Vehicle center y (m).
         heading: Vehicle heading (rad).
-        obstacle_xy: Nearest obstacle point ``[x, y]``.
+        kdtree: KD-tree over the building point cloud.
+        points: Building points array of shape ``(N, 2)``.
 
     Returns:
-        ``True`` when the point falls inside the oriented glyph footprint
+        ``True`` when a point falls inside the oriented glyph footprint
         (plus :data:`_FOOTPRINT_MARGIN_M`), i.e. a visual collision.
     """
-    dx = float(obstacle_xy[0]) - x
-    dy = float(obstacle_xy[1]) - y
+    radius = math.hypot(VEH_HALF_L, VEH_HALF_W) + _FOOTPRINT_MARGIN_M + 1e-6
+    idx = kdtree.query_ball_point([x, y], r=radius)
+    if not idx:
+        return False
     cos_h = math.cos(heading)
     sin_h = math.sin(heading)
-    lx = dx * cos_h + dy * sin_h
-    ly = -dx * sin_h + dy * cos_h
-    return (
-        abs(lx) <= VEH_HALF_L + _FOOTPRINT_MARGIN_M
-        and abs(ly) <= VEH_HALF_W + _FOOTPRINT_MARGIN_M
-    )
+    for i in idx:
+        dx = float(points[i][0]) - x
+        dy = float(points[i][1]) - y
+        lx = dx * cos_h + dy * sin_h
+        ly = -dx * sin_h + dy * cos_h
+        if (
+            abs(lx) <= VEH_HALF_L + _FOOTPRINT_MARGIN_M
+            and abs(ly) <= VEH_HALF_W + _FOOTPRINT_MARGIN_M
+        ):
+            return True
+    return False
 
 
 @dataclass
@@ -142,6 +156,8 @@ def _run_racer(
         return report
     cfg = scene.vehicle_config
     occ = scene._occ
+    obstacle_points = np.asarray(occ.points, dtype=float)
+    obstacle_tree = cKDTree(obstacle_points)
     if tracker_mode == "mpc":
         mpc_cfg = path_following_mpc_config_from_simulator(
             scene._sim_cfg,
@@ -165,11 +181,17 @@ def _run_racer(
         report.max_abs_lat = max(report.max_abs_lat, lat)
         if metrics.get("mpc_solver_success") is False:
             report.solver_failures += 1
-        dist, nearest = occ.nearest_obstacle(
+        dist, _nearest = occ.nearest_obstacle(
             np.array([vehicle.x, vehicle.y], dtype=float)
         )
         report.min_clearance = min(report.min_clearance, float(dist))
-        if _footprint_overlap(vehicle.x, vehicle.y, vehicle.heading, nearest):
+        if _footprint_overlap(
+            vehicle.x,
+            vehicle.y,
+            vehicle.heading,
+            obstacle_tree,
+            obstacle_points,
+        ):
             report.collision_count += 1
         if math.hypot(vehicle.x - gx, vehicle.y - gy) < cfg.goal_radius:
             report.finish_time = t

--- a/tools/mpc_progress_first_demo.py
+++ b/tools/mpc_progress_first_demo.py
@@ -4,8 +4,8 @@ Global planners ignore vehicle dynamics, so a polyline kink sharper than
 ``R_min = v / ω_max`` is not executable at cruise.  This demo shows how
 the executed trajectory evolves under:
 
-1. **Stiff** contouring (``deadzone=0``, ``lag=0``, high contour weight) —
-   the classic fit that stalls / orbits at infeasible corners.
+1. **Stiff** contouring (``deadzone=0``, low progress, high contour
+   weight) — the classic fit that slows hard at infeasible corners.
 2. **Lane-aware progress-first** (city defaults: small free band + lag) —
    the car slows / widens inside the lane while ``s`` advances — without
    treating half the road width as free space into the walls.
@@ -111,8 +111,8 @@ def main() -> Path:
         cruise_speed=cruise,
         weight_contour=12.0,
         weight_heading=6.0,
-        weight_progress=2.0,
-        weight_lag=0.0,
+        weight_progress=0.5,
+        weight_lag=8.0,
         weight_control=0.05,
         weight_obstacle=0.0,
         weight_terminal=20.0,
@@ -157,7 +157,11 @@ def main() -> Path:
     )
     ax.plot(a["x"], a["y"], color="#ef5350", lw=2.0, label="stiff contouring")
     ax.plot(
-        b["x"], b["y"], color="#26a69a", lw=2.2, label="lane-aware progress-first"
+        b["x"],
+        b["y"],
+        color="#26a69a",
+        lw=2.2,
+        label="lane-aware progress-first",
     )
     circ = plt.Circle(
         (20.0 - r_min, 0.0),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes city MPCC zigzag/stall/collision issues and adds GTA2-style car sprites.

### Commit 1 — MPCC formulation & tuning (city)
- Reworked `DubinsPathFollowingMPC` to classical MPCC (virtual progress speed `v_s`, lag error, linear progress reward, B-spline reference interpolants, runway extension, anti-stall warm start)
- Aligned horizon `dt` with simulator timestep (**50 × 0.1 s**)
- Retuned `map/city.yml` weights; added reference-path smoothing with clearance guard

### Commit 2 — GTA2-style car sprites
- New `car_sprite.py` with pixel-art top-down sprites per racer color
- Right-sized vehicle glyphs (`12 × 5.4 m`) to prevent visual corner clipping

### Commit 3 — Documentation
- Updated `control_mpcc.md`, `control_tracking_params.md`, visualization docs

### Follow-up — dt alignment audit (all scenarios)
Audited PPP, RRP, and OCC for the same **model dt ≠ control period** bug that caused city zigzag:

| Scenario | MPC type | Status |
|----------|----------|--------|
| **city** | path-following MPCC | Fixed earlier (50 × 0.1 s) |
| **ppp** | joint-space NMPC | Was internally 0.05/0.05 but unwired — now explicit in YAML + `resolve_sim_timestep` |
| **rrp** | joint-space NMPC | Same as PPP |
| **occ** | none (PD control) | Uses global 0.1 s via `resolve_sim_timestep` |

- Added `resolve_sim_timestep`, `joint_space_mpc_config_from_simulator`
- `JointSpaceMPC.step` now rejects `dt != config.dt`
- Global `mpc.yml` path-following default horizon dt → **0.1 s** (matches `simulator.yml`)
- Regression tests in `test_joint_mpc_horizon.py`

### Verification
- `bash scripts/check_formatting.sh` ✅
- `bash scripts/run_tests.sh` ✅ (811 passed)
- Smoke tests: city, ppp, rrp, occ ✅
- `tools/city_tracking_report.py` — no footprint collisions across planner seeds
- Release-style city video recorded (45 s, all racers finish, no collisions)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29179db5-fc3c-4813-91fc-8b2df94d0c78?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29179db5-fc3c-4813-91fc-8b2df94d0c78&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

