### PR TITLE
feat(planning): modular cost/policy hooks across ARCO (Tier A–C)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -35,7 +35,7 @@ from arco.control import (
     RigidBody, CircleBody, SquareBody,
 )
 from arco.guidance import (
-    BSplineInterpolator, Interpolator,
+    BSplineInterpolator, MovingAverageInterpolator, Interpolator,
     DubinsPrimitive, ExplorationPrimitive,
     DubinsVehicle,
 )
@@ -159,6 +159,7 @@ non-positive `step_size`. Occupied start/goal yields `None` (no exception).
 | Symbol | Role |
 |--------|------|
 | `Interpolator` / `BSplineInterpolator` | Path smoothing (`interpolate`; B-spline is a stub) |
+| `MovingAverageInterpolator` | Moving-average polyline smoother (city references) |
 | `ExplorationPrimitive` / `DubinsPrimitive` | Steering primitives (**not** auto-wired into RRT/SST; inject via `steerer=`) |
 | `DubinsVehicle` | Car-like kinematic model |
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -22,7 +22,7 @@ from arco.mapping import (
     Occupancy, KDTreeOccupancy,
 )
 from arco.planning import (
-    AStar, AStarPlanner, DiscretePlanner,
+    AStar, AStarPlanner, DiscretePlanner, PlannerCost,
     RouteResult, RouteRouter,
     ContinuousPlanner, RRTPlanner, SSTPlanner,
     TrajectoryOptimizer, TrajectoryResult, TrajectoryPruner,
@@ -96,7 +96,8 @@ assert occ.is_occupied(np.array([5.1, 5.1]))
 
 | Symbol | Module | Role |
 |--------|--------|------|
-| `DiscretePlanner` | `planning/discrete/base.py` | ABC: `plan(start, goal)` |
+| `PlannerCost` | `planning/cost.py` | Shared default `distance` / `heuristic` (override to customize) |
+| `DiscretePlanner` | `planning/discrete/base.py` | Inherits `PlannerCost`; graph-backed costs |
 | `AStarPlanner` | `planning/discrete/astar.py` | A* on any graph/grid; `plan`, `plan_with_diagnostics`. Occupied start → `None`. |
 | `AStar` | `planning/discrete/api.py` | Numpy-grid wrapper; `search(start, goal)`. Raises `ValueError` for unknown `grid_type`. |
 | `RouteRouter` | `planning/discrete/route.py` | Project poses → A* on Cartesian/Road graphs |
@@ -120,7 +121,7 @@ path, expanded, parents = AStarPlanner(g).plan_with_diagnostics((0, 0), (19, 19)
 
 | Symbol | Module | Role |
 |--------|--------|------|
-| `ContinuousPlanner` | `planning/continuous/base.py` | ABC: `plan(start, goal)` |
+| `ContinuousPlanner` | `planning/continuous/base.py` | ABC + `PlannerCost`; step-normalized `distance` |
 | `RRTPlanner` | `planning/continuous/rrt.py` | RRT*; `plan`, `get_tree` |
 | `SSTPlanner` | `planning/continuous/sst.py` | SST; `plan`, `get_tree` |
 | `TrajectoryPruner` | `planning/continuous/pruner.py` | Minimum-hop shortcut pruner |

--- a/docs/API.md
+++ b/docs/API.md
@@ -159,13 +159,30 @@ non-positive `step_size`. Occupied start/goal yields `None` (no exception).
 | Symbol | Role |
 |--------|------|
 | `Interpolator` / `BSplineInterpolator` | Path smoothing (`interpolate`; B-spline is a stub) |
-| `ExplorationPrimitive` / `DubinsPrimitive` | Steering primitives |
+| `ExplorationPrimitive` / `DubinsPrimitive` | Steering primitives (**not** auto-wired into RRT/SST; inject via `steerer=`) |
 | `DubinsVehicle` | Car-like kinematic model |
 
 `arco.guidance` also re-exports `Controller`, `PIDController`,
 `PurePursuitController`, `TrackingLoop`, and deprecated `MPCController` from
 `arco.control` for convenience. Prefer importing controllers from
 `arco.control`.
+
+---
+
+## Protocols (`arco.protocols`)
+
+Structural typing contracts for extension points (no runtime enforcement
+beyond `isinstance` with `@runtime_checkable`).  See
+[PLANNING.md](PLANNING.md) § Extension Points.
+
+| Symbol | Role |
+|--------|------|
+| `DiscreteMap` | `neighbors` / `distance` for A* |
+| `OccupancyLike` | Continuous collision queries |
+| `PlannerLike` / `PrunerLike` / `OptimizerLike` | Pipeline stages |
+| `PathTracker` / `VehicleModel` | Tracking-loop injection |
+| `Sampler` / `Steerer` / `SegmentChecker` | Continuous planner policies |
+| `AvoidanceStrategy` / `TelemetryPublisher` / `CostTerm` | Avoidance, telemetry, optimizer terms |
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -30,6 +30,7 @@ from arco.planning import (
 )
 from arco.control import (
     Controller, PIDController, PurePursuitController, TrackingLoop,
+    ArtificialPotentialField,
     DubinsPathFollowingMPC, MPCTrackingLoop, ReferencePath,
     JointSpaceMPC, JointSpaceTracker, ActuatorArray,
     RigidBody, CircleBody, SquareBody,
@@ -142,7 +143,8 @@ non-positive `step_size`. Occupied start/goal yields `None` (no exception).
 | `Controller` | ABC: `control(state, reference)` |
 | `PIDController` | Classic PID |
 | `PurePursuitController` | Geometric look-ahead tracker |
-| `TrackingLoop` | Pure Pursuit integration (+ optional APF) |
+| `TrackingLoop` | Path-tracker integration (+ injectable avoidance) |
+| `ArtificialPotentialField` | Default APF turn-rate avoidance (`AvoidanceStrategy`) |
 | `DubinsPathFollowingMPC` | CasADi contouring NMPC / NMPCC-style (`arco[mpc]`; see [control_mpcc.md](control_mpcc.md)) |
 | `MPCTrackingLoop` | Metrics loop for path-following MPC |
 | `ReferencePath` / `PathFollowingMPCConfig` / `DubinsVehicleLimits` | MPC inputs |

--- a/docs/GUIDANCE.md
+++ b/docs/GUIDANCE.md
@@ -67,6 +67,13 @@ Feedback controllers that generate control inputs to track a reference trajector
   - Used by PPP / RRP when `tracker: mpc`
 
 - **MPCTrackingLoop** / **TrackingLoop**: integration loops for MPC and Pure Pursuit
+  - `TrackingLoop` accepts `VehicleModel` / `PathTracker` duck types and an
+    optional `avoidance=` strategy (`AvoidanceStrategy`).  When omitted,
+    `occupancy` + `repulsion_gain` build the default
+    `ArtificialPotentialField` (same APF behaviour as before).
+- **ArtificialPotentialField** (`arco.control.avoidance`): default APF
+  turn-rate bias; construct with `occupancy=None` / `repulsion_gain<=0`
+  for a no-op disable path.
 
 - **MPCController**: Deprecated scalar stub — use `DubinsPathFollowingMPC`
 

--- a/docs/GUIDANCE.md
+++ b/docs/GUIDANCE.md
@@ -97,6 +97,12 @@ Kinematic motion primitives for graph exploration and steering.
 
 All primitives inherit from the `ExplorationPrimitive` abstract base class (`primitive/base.py`).
 
+**Wiring status:** RRT* / SST do **not** call `ExplorationPrimitive` by
+default.  Default steering is geometric straight-line extension.  Pass a
+primitive-backed callable via `RRTPlanner(..., steerer=...)` /
+`SSTPlanner(..., steerer=...)` to enable kinodynamic expansion.  See
+[PLANNING.md](PLANNING.md) § Extension Points.
+
 ### Vehicle Models (`arco.guidance.vehicle`)
 
 Kinematic and dynamic models for different vehicle types.

--- a/docs/PLANNING.md
+++ b/docs/PLANNING.md
@@ -50,7 +50,8 @@ on a planner subclass to customize costs without rewriting search loops.
 | `heuristic(a, b)` | same as `distance` | `graph.heuristic` or `distance` | same as continuous `distance` |
 
 A* also accepts an optional `heuristic=` callable in its constructor.
-The trajectory optimizer keeps its own composite cost (weights only).
+The trajectory optimizer accepts optional ``cost_terms=`` (defaults to the
+five historical weighted terms).
 
 ## Extension Points
 

--- a/docs/PLANNING.md
+++ b/docs/PLANNING.md
@@ -22,20 +22,35 @@ The planning layer in ARCO provides algorithms for finding feasible paths throug
 ```
 src/arco/planning/
 ├── __init__.py
+├── cost.py              ← PlannerCost (default distance + heuristic)
 ├── discrete/
 │   ├── __init__.py
-│   ├── base.py          ← DiscretePlanner abstract base
+│   ├── base.py          ← DiscretePlanner (inherits PlannerCost)
 │   ├── astar.py         ← A* planner implementation
 │   ├── dstar.py         ← D* Lite stub
 │   ├── route.py         ← Route planning (A* for road networks)
 │   └── api.py           ← Public API wrappers (AStar, DStarLite)
 └── continuous/
     ├── __init__.py
-    ├── base.py          ← ContinuousPlanner abstract base
+    ├── base.py          ← ContinuousPlanner (inherits PlannerCost)
     ├── rrt.py           ← RRT* planner implementation
     ├── sst.py           ← SST planner implementation
     └── optimizer.py     ← TrajectoryOptimizer (two-stage refinement)
 ```
+
+## Cost Functions
+
+A*, RRT*, and SST share :class:`~arco.planning.cost.PlannerCost` through
+their discrete/continuous bases.  Override `distance` and/or `heuristic`
+on a planner subclass to customize costs without rewriting search loops.
+
+| Method | Default (`PlannerCost`) | Discrete override | Continuous override |
+|---|---|---|---|
+| `distance(a, b)` | Euclidean | `graph.distance` | step-size-normalized Euclidean |
+| `heuristic(a, b)` | same as `distance` | `graph.heuristic` or `distance` | same as continuous `distance` |
+
+A* also accepts an optional `heuristic=` callable in its constructor.
+The trajectory optimizer keeps its own composite cost (weights only).
 
 ## References
 - See [README.md](../README.md) for global references.

--- a/docs/PLANNING.md
+++ b/docs/PLANNING.md
@@ -52,8 +52,45 @@ on a planner subclass to customize costs without rewriting search loops.
 A* also accepts an optional `heuristic=` callable in its constructor.
 The trajectory optimizer keeps its own composite cost (weights only).
 
+## Extension Points
+
+Structural contracts live in `arco.protocols`.  Library defaults always
+preserve historical behavior; optional overrides are opt-in.
+
+| Hook | Where | Default | Override |
+|---|---|---|---|
+| `distance` / `heuristic` | `PlannerCost` (A*/RRT*/SST) | Euclidean / graph / step-normalized | Subclass or inject `cost=` |
+| `heuristic=` callable | `AStarPlanner` ctor | `graph.heuristic` or `distance` | Pass callable |
+| `sampler=` / `steerer=` / `segment_free=` | `RRTPlanner`, `SSTPlanner` | Uniform AABB, straight-line step, point occupancy samples | Callables / protocols |
+| `cost=` | Continuous planners | Planner's own `PlannerCost` methods | `PlannerCost` instance |
+| `planner=` | `RouteRouter` | Internal `AStarPlanner` | Any discrete planner with `plan` |
+| `simplify_path` / `prefer_straight` | `AStarPlanner` | `True` / `True` | Disable via ctor flags |
+| `publisher=` / `seed=` | Continuous planners | File telemetry / unseeded RNG | Custom sink / seed |
+| `steer=` | `TrajectoryPruner.prune` | Occupancy segment check | Feasibility callable |
+| `feasibility=` / `inverse_kinematics=` | `TrajectoryOptimizer.optimize` | None (geometry-only) | Callables |
+| `cost_terms=` | `TrajectoryOptimizer` | Five default weighted terms | Replace/append terms |
+
+### Guidance primitives and RRT-family planners
+
+`:class:`~arco.guidance.primitive.base.ExplorationPrimitive`` (and
+`DubinsPrimitive`) define a steerer ABC intended for kinodynamic RRT/SST.
+They are **not** auto-wired into `RRTPlanner` / `SSTPlanner`.  Default
+steering remains geometric straight-line extension.
+
+To use a primitive, wrap it as a `steerer=` callable::
+
+    primitive = DubinsPrimitive(...)
+    planner = RRTPlanner(
+        occ,
+        bounds=bounds,
+        steerer=lambda a, b: primitive.steer(a, b)[-1],
+    )
+
+Until a steerer is injected, treating RRT/SST as kinodynamic is incorrect.
+
 ## References
 - See [README.md](../README.md) for global references.
+- See `arco.protocols` for structural typing contracts.
 
 ---
 

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -160,6 +160,9 @@ Tunable algorithm parameters belong in `.yml` files under `config/`. The YAML st
 - Planning algorithms accept a **map** object as their first argument.
   - Grid-based planners (`AStarPlanner`, `DStarPlanner`) require a `Grid` subclass.
   - Sampling-based planners (`RRTPlanner`, `SSTPlanner`) require an `Occupancy` subclass.
+- A*, RRT*, and SST inherit :class:`~arco.planning.cost.PlannerCost` (via
+  `DiscretePlanner` / `ContinuousPlanner`).  Override `distance` and/or
+  `heuristic` to customize path cost without rewriting the search loop.
 - The **guidance** layer is applied after planning; it handles interpolation (B-splines) and exploration primitives (Dubins, Reeds-Shepp) for RRT-family algorithms.
 - The `AStarPlanner` uses `graph.heuristic` (Euclidean distance) as the default heuristic, not `graph.distance` (Manhattan). This prevents L-shaped paths on symmetric Manhattan grids.
 

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -163,7 +163,13 @@ Tunable algorithm parameters belong in `.yml` files under `config/`. The YAML st
 - A*, RRT*, and SST inherit :class:`~arco.planning.cost.PlannerCost` (via
   `DiscretePlanner` / `ContinuousPlanner`).  Override `distance` and/or
   `heuristic` to customize path cost without rewriting the search loop.
-- The **guidance** layer is applied after planning; it handles interpolation (B-splines) and exploration primitives (Dubins, Reeds-Shepp) for RRT-family algorithms.
+- Optional policy hooks (`sampler=`, `steerer=`, `segment_free=`, `cost=`,
+  telemetry `publisher=`, optimizer `cost_terms=`, tracking avoidance)
+  always default to historical behavior.  See [PLANNING.md](PLANNING.md)
+  § Extension Points and `arco.protocols`.
+- The **guidance** layer provides interpolation and exploration primitives.
+  `ExplorationPrimitive` is **not** auto-wired into RRT/SST; inject it via
+  `steerer=` when kinodynamic expansion is required.
 - The `AStarPlanner` uses `graph.heuristic` (Euclidean distance) as the default heuristic, not `graph.distance` (Manhattan). This prevents L-shaped paths on symmetric Manhattan grids.
 
 

--- a/docs/planning_astar.md
+++ b/docs/planning_astar.md
@@ -13,9 +13,13 @@ A* is a best-first, graph-based search algorithm that finds the shortest path fr
 - Returns optimal path if heuristic is admissible
 
 ## Implementation Features
-- Grid-based, configurable heuristic (default: Manhattan)
+- Grid-based, configurable heuristic (constructor callable or method override)
+- Edge cost via overridable :meth:`~arco.planning.cost.PlannerCost.distance`
+  (defaults to ``graph.distance``)
 - Returns path as a list of coordinates
 - Avoids obstacles (grid cells with value 1)
+- Inherits :class:`~arco.planning.cost.PlannerCost` through
+  :class:`~arco.planning.discrete.base.DiscretePlanner`
 
 ## Example Usage
 ```python

--- a/docs/planning_rrt.md
+++ b/docs/planning_rrt.md
@@ -31,6 +31,7 @@ RRT* extends the basic RRT algorithm with two key improvements:
 - [x] Early stopping option for first-solution mode
 - [x] Configurable step size and sample limits
 - [x] Tree export for visualization via `get_tree(start, goal)` → `(nodes, parent, path)`
+- [x] Overridable `distance` / `heuristic` via `PlannerCost` (step-size-normalized Euclidean by default)
 
 ### Configuration Parameters
 

--- a/docs/planning_sst.md
+++ b/docs/planning_sst.md
@@ -33,6 +33,7 @@ SST addresses the challenge of kinodynamic planning (planning with dynamics cons
 - [x] Early stopping option
 - [x] Configurable witness radius and step size
 - [x] Tree export for visualization via `get_tree(start, goal)` → `(active_nodes, active_parent, path)`
+- [x] Overridable `distance` / `heuristic` via `PlannerCost` (step-size-normalized Euclidean by default)
 
 ### Configuration Parameters
 

--- a/src/arco/__init__.py
+++ b/src/arco/__init__.py
@@ -7,6 +7,7 @@ from . import (
     middleware,
     pipeline,
     planning,
+    protocols,
 )
 
 __all__ = [
@@ -17,4 +18,5 @@ __all__ = [
     "middleware",
     "pipeline",
     "planning",
+    "protocols",
 ]

--- a/src/arco/control/__init__.py
+++ b/src/arco/control/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from arco.control.actuator import ActuatorArray
+from arco.control.avoidance import ArtificialPotentialField
 from arco.control.base import Controller
 from arco.control.joint_tracker import JointSpaceTracker
 from arco.control.mpc import (
@@ -24,6 +25,7 @@ from arco.control.tracking import TrackingLoop
 
 __all__ = [
     "ActuatorArray",
+    "ArtificialPotentialField",
     "CircleBody",
     "Controller",
     "DubinsPathFollowingMPC",

--- a/src/arco/control/avoidance.py
+++ b/src/arco/control/avoidance.py
@@ -1,0 +1,109 @@
+"""ArtificialPotentialField: reactive APF turn-rate avoidance strategy."""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from arco.mapping.occupancy import Occupancy
+
+
+class ArtificialPotentialField:
+    """Artificial Potential Field turn-rate bias for obstacle avoidance.
+
+    Implements the reactive APF correction historically inlined in
+    :class:`~arco.control.tracking.TrackingLoop`.  When the vehicle is
+    within ``2 × clearance`` of the nearest obstacle, returns an additive
+    turn-rate bias that steers away from the obstacle.  The magnitude is
+    proportional to ``repulsion_gain × (1/d − 1/d_max)`` where *d* is the
+    obstacle distance and *d_max* = 2 × clearance.
+
+    Callables of this class satisfy
+    :class:`~arco.protocols.avoidance.AvoidanceStrategy`.
+
+    A no-op / disabled instance is obtained by constructing with
+    ``occupancy=None`` and/or ``repulsion_gain <= 0``; ``__call__`` then
+    always returns ``0.0``.
+
+    Attributes:
+        repulsion_gain: Obstacle-repulsion turn-rate gain (rad/m).  A
+            value of ``0.0`` disables repulsion.
+    """
+
+    def __init__(
+        self,
+        occupancy: Optional["Occupancy"] = None,
+        repulsion_gain: float = 0.0,
+    ) -> None:
+        """Initialize ArtificialPotentialField.
+
+        Args:
+            occupancy: Optional occupancy map used to query the nearest
+                obstacle.  When ``None`` (default), every call returns
+                ``0.0``.
+            repulsion_gain: Obstacle-repulsion turn-rate gain (rad/m).
+                Non-positive values disable repulsion (no-op path).
+                Typical range: ``0.5``–``3.0``.
+        """
+        self._occupancy = occupancy
+        self.repulsion_gain = float(repulsion_gain)
+
+    def __call__(self, x: float, y: float, theta: float) -> float:
+        """Return an APF obstacle-repulsion turn-rate correction.
+
+        Returns an additive turn-rate (rad/s) that steers the vehicle away
+        from the nearest obstacle when it is within ``2 × clearance``
+        meters.  The magnitude follows the standard APF formula::
+
+            Δω = −gain × (1/d − 1/d_max) × sign(lateral)
+
+        where *d* is the distance to the nearest obstacle, *d_max* is the
+        influence radius (2 × clearance), and *lateral* is the signed
+        lateral displacement of the obstacle from the vehicle's heading
+        (positive = obstacle is to the vehicle's left).
+
+        The sign convention steers *away* from the obstacle:
+        obstacle to the left  → negative Δω (turn right);
+        obstacle to the right → positive Δω (turn left).
+
+        Args:
+            x: Vehicle x-position in world frame (m).
+            y: Vehicle y-position in world frame (m).
+            theta: Vehicle heading in radians.
+
+        Returns:
+            Turn-rate correction in rad/s; ``0.0`` when disabled, outside
+            the influence radius, or when no occupancy map is configured.
+        """
+        if self._occupancy is None or self.repulsion_gain <= 0.0:
+            return 0.0
+        clearance: float = getattr(self._occupancy, "clearance", 0.0)
+        if clearance <= 0.0 or not hasattr(
+            self._occupancy, "nearest_obstacle"
+        ):
+            return 0.0
+
+        influence_radius = 2.0 * clearance
+        pt = np.array([x, y], dtype=float)
+        dist, nearest = self._occupancy.nearest_obstacle(pt)  # type: ignore[attr-defined]
+        if dist >= influence_radius or dist < 1e-6:
+            return 0.0
+
+        # Signed lateral displacement of the obstacle from the vehicle axis.
+        # Vehicle lateral direction (pointing LEFT of heading) is
+        # (−sin θ, cos θ).
+        dx = float(nearest[0]) - x
+        dy = float(nearest[1]) - y
+        lateral = dx * (-math.sin(theta)) + dy * math.cos(theta)
+
+        # APF magnitude: (1/d − 1/d_max) with distance clamped for stability.
+        magnitude = self.repulsion_gain * (
+            1.0 / max(dist, 0.1 * clearance) - 1.0 / influence_radius
+        )
+
+        # Steer away: obstacle to the left (lateral > 0) → turn right (Δω < 0)
+        lateral_sign = math.copysign(1.0, lateral)
+        return -magnitude * lateral_sign

--- a/src/arco/control/mpc/__init__.py
+++ b/src/arco/control/mpc/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from arco.control.mpc.base import MPCTracker
 from arco.control.mpc.controller import MPCController
+from arco.control.mpc.costs import forward_cone_factor, obstacle_barrier
 from arco.control.mpc.joint_space import JointSpaceMPC, JointSpaceMPCConfig
 from arco.control.mpc.path_following import (
     DubinsPathFollowingMPC,
@@ -25,4 +26,6 @@ __all__ = [
     "MPCTrackingLoop",
     "PathFollowingMPCConfig",
     "ReferencePath",
+    "forward_cone_factor",
+    "obstacle_barrier",
 ]

--- a/src/arco/control/mpc/costs.py
+++ b/src/arco/control/mpc/costs.py
@@ -1,49 +1,66 @@
-"""Private cost helpers for path-following MPC."""
+"""Shared soft-barrier cost helpers for path-following and joint-space MPC.
+
+Used by :mod:`arco.control.mpc.path_following` and
+:mod:`arco.control.mpc.joint_space` for clearance penetration penalties
+(and forward-cone weighting on the SE(2) path-following controller).
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
 
+def _is_casadi(value: Any) -> bool:
+    """Return True if *value* is a CasADi SX, MX, or DM."""
+    try:
+        import casadi as ca
+
+        return isinstance(value, (ca.SX, ca.MX, ca.DM))
+    except ImportError:
+        return False
+
+
 def obstacle_barrier(
     distance: Any,
-    clearance: float,
+    clearance: Any,
     weight: float,
     power: float,
     cone_factor: Any,
 ) -> Any:
     """Soft clearance barrier with forward-cone weighting.
 
-    Matches the :class:`~arco.planning.continuous.optimizer.TrajectoryOptimizer`
+    Matches the inlined barrier used by path-following / joint-space MPC
+    and the :class:`~arco.planning.continuous.optimizer.TrajectoryOptimizer`
     philosophy: penalize penetration of the clearance margin with a power
     barrier, then weight by directional relevance along the velocity cone.
 
+    Joint-space MPC (no heading) passes ``cone_factor=1.0`` so the
+    directional term is exactly ``1``.
+
     Args:
         distance: Distance to the nearest obstacle (symbolic or float).
-        clearance: Required clearance radius (m). Must be positive.
+        clearance: Required clearance radius (m). May be a CasADi Opti
+            parameter. Must be positive at solve time.
         weight: Barrier weight.
         power: Barrier exponent.
         cone_factor: Forward-cone factor in ``[0, 1]`` (1 ahead, 0 behind).
+            Use ``1.0`` when no cone weighting applies.
 
     Returns:
-        Scalar barrier cost (same type as *distance* / *cone_factor*).
+        Scalar barrier cost (same type family as *distance* /
+        *cone_factor*).
     """
-    safe_clearance = max(float(clearance), 1e-6)
-    # penetration ratio: max(0, -(d - clearance) / clearance)
-    # = max(0, (clearance - d) / clearance)
-    penetration = (safe_clearance - distance) / safe_clearance
-    # Use fmax for CasADi compatibility; also works for floats.
-    try:
+    if _is_casadi(distance) or _is_casadi(clearance):
         import casadi as ca
 
-        if isinstance(distance, (ca.SX, ca.MX, ca.DM)):
-            penetration = ca.fmax(0.0, penetration)
-            directional = 0.2 + 0.8 * cone_factor
-            return weight * (penetration**power) * directional
-    except ImportError:
-        pass
+        # Match NLP inlining: (c - d) / max(c, eps), then clamp.
+        penetration = (clearance - distance) / ca.fmax(clearance, 1e-6)
+        penetration = ca.fmax(0.0, penetration)
+        directional = 0.2 + 0.8 * cone_factor
+        return weight * (penetration**power) * directional
 
-    penetration_f = max(0.0, float(penetration))
+    denom = max(float(clearance), 1e-6)
+    penetration_f = max(0.0, (float(clearance) - float(distance)) / denom)
     directional_f = 0.2 + 0.8 * float(cone_factor)
     return float(weight) * (penetration_f**power) * directional_f
 
@@ -55,7 +72,14 @@ def forward_cone_factor(
     obstacle_x: Any,
     obstacle_y: Any,
 ) -> Any:
-    """Return ``max(0, cos(heading − bearing_to_obstacle))``.
+    """Smooth forward-cone factor via heading–bearing projection.
+
+    Uses the unit obstacle offset projected onto the vehicle heading,
+    clamped to ``[0, 1]``.  This matches the path-following MPC
+    formulation (no ``atan2`` kinks in the NLP graph).
+
+    Numerically equal to ``max(0, cos(heading − bearing))`` for nonzero
+    separation.
 
     Args:
         pose_x: Vehicle x position.
@@ -67,19 +91,21 @@ def forward_cone_factor(
     Returns:
         Cone factor in ``[0, 1]`` (symbolic or float).
     """
-    try:
+    if _is_casadi(pose_x) or _is_casadi(obstacle_x):
         import casadi as ca
 
-        if isinstance(pose_x, (ca.SX, ca.MX, ca.DM)):
-            bearing = ca.atan2(obstacle_y - pose_y, obstacle_x - pose_x)
-            return ca.fmax(0.0, ca.cos(heading - bearing))
-    except ImportError:
-        pass
+        dx = obstacle_x - pose_x
+        dy = obstacle_y - pose_y
+        dist = ca.sqrt(dx**2 + dy**2 + 1e-9)
+        fwd = (ca.cos(heading) * dx + ca.sin(heading) * dy) / dist
+        return ca.fmax(0.0, fwd)
 
     import math
 
-    bearing = math.atan2(
-        float(obstacle_y) - float(pose_y),
-        float(obstacle_x) - float(pose_x),
-    )
-    return max(0.0, math.cos(float(heading) - bearing))
+    dx = float(obstacle_x) - float(pose_x)
+    dy = float(obstacle_y) - float(pose_y)
+    dist = math.sqrt(dx * dx + dy * dy + 1e-9)
+    fwd = (
+        math.cos(float(heading)) * dx + math.sin(float(heading)) * dy
+    ) / dist
+    return max(0.0, fwd)

--- a/src/arco/control/mpc/joint_space.py
+++ b/src/arco/control/mpc/joint_space.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import numpy as np
 
 from arco.config import load_config
+from arco.control.mpc.costs import obstacle_barrier
 
 if TYPE_CHECKING:
     from arco.mapping.occupancy import Occupancy
@@ -308,12 +309,13 @@ class JointSpaceMPC:
                 for j in range(obstacle_count):
                     diff = q_k - obs[:, j]
                     dist = ca.sqrt(ca.sumsqr(diff) + 1e-9)
-                    penetration = (clearance_p - dist) / ca.fmax(
-                        clearance_p, 1e-6
-                    )
-                    penetration = ca.fmax(0.0, penetration)
-                    cost += cfg.weight_obstacle * (
-                        penetration**cfg.obstacle_barrier_power
+                    # No heading cone in C-space: directional weight ≡ 1.
+                    cost += obstacle_barrier(
+                        dist,
+                        clearance_p,
+                        cfg.weight_obstacle,
+                        cfg.obstacle_barrier_power,
+                        cone_factor=1.0,
                     )
 
             v_next = v_k + a_k * dt

--- a/src/arco/control/mpc/path_following.py
+++ b/src/arco/control/mpc/path_following.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from arco.config import load_config
 from arco.control.mpc.base import MPCTracker
+from arco.control.mpc.costs import forward_cone_factor, obstacle_barrier
 from arco.control.mpc.reference_path import ReferencePath
 from arco.control.mpc.result import MPCStepResult
 
@@ -835,22 +836,13 @@ class DubinsPathFollowingMPC(MPCTracker):
                     ox = obs[0, j]
                     oy = obs[1, j]
                     dist = ca.sqrt((px - ox) ** 2 + (py - oy) ** 2 + 1e-9)
-                    # Smooth forward-cone factor (no atan2 kinks): the
-                    # projection of the unit obstacle bearing onto the
-                    # vehicle heading, clamped to [0, 1].
-                    fwd = (
-                        ca.cos(theta) * (ox - px) + ca.sin(theta) * (oy - py)
-                    ) / dist
-                    cone = ca.fmax(0.0, fwd)
-                    penetration = (clearance_p - dist) / ca.fmax(
-                        clearance_p, 1e-6
-                    )
-                    penetration = ca.fmax(0.0, penetration)
-                    directional = 0.2 + 0.8 * cone
-                    cost += (
-                        cfg.weight_obstacle
-                        * (penetration**cfg.obstacle_barrier_power)
-                        * directional
+                    cone = forward_cone_factor(px, py, theta, ox, oy)
+                    cost += obstacle_barrier(
+                        dist,
+                        clearance_p,
+                        cfg.weight_obstacle,
+                        cfg.obstacle_barrier_power,
+                        cone,
                     )
 
             v_next = v + a * dt

--- a/src/arco/control/tracking.py
+++ b/src/arco/control/tracking.py
@@ -2,74 +2,83 @@
 
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING, Any, Optional
 
+from .avoidance import ArtificialPotentialField
+
 if TYPE_CHECKING:
-    from arco.guidance.vehicle import DubinsVehicle
     from arco.mapping.occupancy import Occupancy
-
-import numpy as np
-
-from .pure_pursuit import PurePursuitController
+    from arco.protocols.avoidance import AvoidanceStrategy
+    from arco.protocols.path_tracker import PathTracker
+    from arco.protocols.vehicle import VehicleModel
 
 
 class TrackingLoop:
     """Local tracking loop combining a vehicle model and a path controller.
 
-    Closes the feedback loop between a :class:`~arco.guidance.vehicle.DubinsVehicle`
-    kinematic model and a :class:`PurePursuitController`.  Each call to
-    :meth:`step` issues pure pursuit commands to the vehicle and records
-    cross-track error, heading error, pose, speed, and turn rate for later
-    analysis.
+    Closes the feedback loop between a
+    :class:`~arco.protocols.vehicle.VehicleModel`-compatible kinematic
+    model and a :class:`~arco.protocols.path_tracker.PathTracker`-compatible
+    controller.  Each call to :meth:`step` issues tracking commands to the
+    vehicle and records cross-track error, heading error, pose, speed, and
+    turn rate for later analysis.
 
-    When an *occupancy* map and a positive *repulsion_gain* are provided, a
-    reactive obstacle-repulsion correction is blended into the turn-rate
-    command at every step.  The correction is an Artificial Potential Field
-    (APF) lateral force: when the vehicle is within ``2 × clearance`` of the
-    nearest obstacle, a turn-rate bias is added that steers the vehicle away
-    from the obstacle.  The bias magnitude is proportional to
-    ``repulsion_gain × (1/d − 1/d_max)`` where *d* is the obstacle distance
-    and *d_max* = 2 × clearance is the influence radius.  This prevents the
-    vehicle from crashing into obstacles even when the planned trajectory
-    skirts obstacle boundaries.
+    When an *occupancy* map and a positive *repulsion_gain* are provided
+    (and *avoidance* is omitted), a default
+    :class:`~arco.control.avoidance.ArtificialPotentialField` correction is
+    blended into the turn-rate command at every step.  Pass an explicit
+    *avoidance* strategy to replace the inline APF; pass ``None`` with
+    non-positive *repulsion_gain* (or no occupancy) to disable repulsion.
 
     Attributes:
         vehicle: Kinematic vehicle model.
-        controller: Pure pursuit path-tracking controller.
+        controller: Path-tracking controller.
         cruise_speed: Desired forward speed passed to the controller (m/s).
         curvature_gain: Curvature-to-speed scaling factor (m).  Speed is
             modulated as ``v = cruise_speed / (1 + curvature_gain * |κ|)``
-            where *κ* is the pure pursuit curvature from the previous step.
+            where *κ* is the tracker curvature from the previous step.
             A value of ``0.0`` (default) disables modulation.
-        repulsion_gain: Obstacle-repulsion turn-rate gain (rad/m).  A value
-            of ``0.0`` (default) disables repulsion.
+        repulsion_gain: Obstacle-repulsion turn-rate gain (rad/m) used when
+            building the default APF.  A value of ``0.0`` (default)
+            disables repulsion unless a custom *avoidance* is supplied.
     """
 
     def __init__(
         self,
-        vehicle: DubinsVehicle,
-        controller: PurePursuitController,
+        vehicle: "VehicleModel",
+        controller: "PathTracker",
         cruise_speed: float = 1.0,
         curvature_gain: float = 0.0,
         occupancy: Optional["Occupancy"] = None,
         repulsion_gain: float = 0.0,
+        avoidance: Optional["AvoidanceStrategy"] = None,
     ) -> None:
         """Initialize TrackingLoop.
 
         Args:
-            vehicle: Kinematic vehicle model.
-            controller: Pure pursuit path-tracking controller.
+            vehicle: Kinematic vehicle model satisfying
+                :class:`~arco.protocols.vehicle.VehicleModel`.
+            controller: Path tracker satisfying
+                :class:`~arco.protocols.path_tracker.PathTracker`.
             cruise_speed: Desired forward speed (m/s).
             curvature_gain: Speed-modulation gain (m).  Set to ``0.0`` to
                 keep a constant cruise speed.  Positive values slow the
                 vehicle on curves: ``v = cruise_speed / (1 + gain * |κ|)``.
-            occupancy: Optional occupancy map used to compute obstacle
-                repulsion.  When ``None`` (default) or when *repulsion_gain*
-                is ``0.0``, no repulsion correction is applied.
-            repulsion_gain: Obstacle-repulsion turn-rate gain (rad/m).
-                Positive values add a corrective turn when the vehicle
-                approaches obstacles.  Typical range: ``0.5``–``3.0``.
+            occupancy: Optional occupancy map used to build the default
+                APF when *avoidance* is ``None``.  Ignored when a custom
+                *avoidance* is provided.  When ``None`` (default) or when
+                *repulsion_gain* is ``0.0``, no default repulsion is
+                applied.
+            repulsion_gain: Obstacle-repulsion turn-rate gain (rad/m) for
+                the default APF.  Positive values add a corrective turn
+                when the vehicle approaches obstacles.  Typical range:
+                ``0.5``–``3.0``.  Kept for backwards compatibility.
+            avoidance: Optional
+                :class:`~arco.protocols.avoidance.AvoidanceStrategy`.
+                When provided, it is used instead of the default APF.
+                When ``None`` and *repulsion_gain* > 0 with *occupancy*
+                set, an :class:`ArtificialPotentialField` is constructed
+                with the same behaviour as the historical inline APF.
         """
         self.vehicle = vehicle
         self.controller = controller
@@ -77,6 +86,15 @@ class TrackingLoop:
         self.curvature_gain = curvature_gain
         self._occupancy = occupancy
         self.repulsion_gain = repulsion_gain
+        if avoidance is not None:
+            self._avoidance: Optional["AvoidanceStrategy"] = avoidance
+        elif occupancy is not None and repulsion_gain > 0.0:
+            self._avoidance = ArtificialPotentialField(
+                occupancy=occupancy,
+                repulsion_gain=repulsion_gain,
+            )
+        else:
+            self._avoidance = None
         self._history: list[dict[str, Any]] = []
 
     # ------------------------------------------------------------------
@@ -98,22 +116,11 @@ class TrackingLoop:
     # ------------------------------------------------------------------
 
     def _repulsion_turn_rate(self, x: float, y: float, theta: float) -> float:
-        """Compute an APF obstacle-repulsion turn-rate correction.
+        """Compute an obstacle-repulsion turn-rate correction.
 
-        Returns an additive turn-rate (rad/s) that steers the vehicle away
-        from the nearest obstacle when it is within ``2 × clearance`` meters.
-        The magnitude follows the standard APF formula::
-
-            Δω = −gain × (1/d − 1/d_max) × sign(lateral)
-
-        where *d* is the distance to the nearest obstacle, *d_max* is the
-        influence radius (2 × clearance), and *lateral* is the signed
-        lateral displacement of the obstacle from the vehicle's heading
-        (positive = obstacle is to the vehicle's left).
-
-        The sign convention steers *away* from the obstacle:
-        obstacle to the left  → negative Δω (turn right);
-        obstacle to the right → positive Δω (turn left).
+        Delegates to the configured :class:`~arco.protocols.avoidance.AvoidanceStrategy`
+        (default APF or an injected strategy).  Returns ``0.0`` when
+        avoidance is disabled.
 
         Args:
             x: Vehicle x-position in world frame (m).
@@ -121,38 +128,12 @@ class TrackingLoop:
             theta: Vehicle heading in radians.
 
         Returns:
-            Turn-rate correction in rad/s; ``0.0`` when outside influence
-            radius or when no occupancy map is configured.
+            Turn-rate correction in rad/s; ``0.0`` when avoidance is
+            disabled.
         """
-        if self._occupancy is None or self.repulsion_gain <= 0.0:
+        if self._avoidance is None:
             return 0.0
-        clearance: float = getattr(self._occupancy, "clearance", 0.0)
-        if clearance <= 0.0 or not hasattr(
-            self._occupancy, "nearest_obstacle"
-        ):
-            return 0.0
-
-        influence_radius = 2.0 * clearance
-        pt = np.array([x, y], dtype=float)
-        dist, nearest = self._occupancy.nearest_obstacle(pt)  # type: ignore[attr-defined]
-        if dist >= influence_radius or dist < 1e-6:
-            return 0.0
-
-        # Signed lateral displacement of the obstacle from the vehicle axis.
-        # Vehicle lateral direction (pointing LEFT of heading) is
-        # (−sin θ, cos θ).
-        dx = float(nearest[0]) - x
-        dy = float(nearest[1]) - y
-        lateral = dx * (-math.sin(theta)) + dy * math.cos(theta)
-
-        # APF magnitude: (1/d − 1/d_max) with distance clamped for stability.
-        magnitude = self.repulsion_gain * (
-            1.0 / max(dist, 0.1 * clearance) - 1.0 / influence_radius
-        )
-
-        # Steer away: if obstacle is to the left (lateral > 0) → turn right (Δω < 0)
-        lateral_sign = math.copysign(1.0, lateral)
-        return -magnitude * lateral_sign
+        return float(self._avoidance(x, y, theta))
 
     # ------------------------------------------------------------------
     # Simulation
@@ -167,9 +148,10 @@ class TrackingLoop:
         current vehicle pose and reference path, applies them to the vehicle
         model, then records and returns the resulting metrics.
 
-        When an occupancy map and a positive repulsion gain are configured,
-        an obstacle-avoidance correction is blended into the turn-rate
-        command before the vehicle is integrated.
+        When an avoidance strategy is configured (explicitly or via the
+        default APF from occupancy / repulsion_gain), an obstacle-avoidance
+        correction is blended into the turn-rate command before the vehicle
+        is integrated.
 
         Args:
             path: Reference path as an ordered list of ``(x, y)`` waypoints.
@@ -185,7 +167,7 @@ class TrackingLoop:
             - ``pose``: current vehicle pose ``(x, y, heading)``.
             - ``speed``: current vehicle speed (m/s).
             - ``turn_rate``: current vehicle turn rate (rad/s).
-            - ``curvature``: pure pursuit curvature used this step (rad/m).
+            - ``curvature``: tracker curvature used this step (rad/m).
             - ``repulsion_turn_rate``: obstacle-repulsion correction added
               to the turn-rate command (rad/s).  Zero when repulsion is
               disabled.

--- a/src/arco/guidance/__init__.py
+++ b/src/arco/guidance/__init__.py
@@ -22,7 +22,11 @@ from arco.control import (
     TrackingLoop,
 )
 
-from .interpolation import BSplineInterpolator, Interpolator
+from .interpolation import (
+    BSplineInterpolator,
+    Interpolator,
+    MovingAverageInterpolator,
+)
 from .primitive import DubinsPrimitive, ExplorationPrimitive
 from .vehicle import DubinsVehicle
 
@@ -33,6 +37,7 @@ __all__ = [
     "DubinsVehicle",
     "ExplorationPrimitive",
     "Interpolator",
+    "MovingAverageInterpolator",
     "MPCController",
     "PIDController",
     "PurePursuitController",

--- a/src/arco/mapping/grid/__init__.py
+++ b/src/arco/mapping/grid/__init__.py
@@ -1,3 +1,11 @@
+"""Grid map representations."""
+
 from .base import Grid
 from .euclidean import EuclideanGrid
 from .manhattan import ManhattanGrid
+
+__all__ = [
+    "EuclideanGrid",
+    "Grid",
+    "ManhattanGrid",
+]

--- a/src/arco/mapping/occupancy.py
+++ b/src/arco/mapping/occupancy.py
@@ -22,14 +22,7 @@ class Occupancy(Graph, ABC):
     ``getattr`` / ``hasattr`` branching.
     """
 
-    @property
-    def clearance(self) -> float:
-        """Minimum free margin around obstacles (meters).
-
-        Defaults to ``0.0`` (binary occupancy only).  Concrete maps such as
-        :class:`~arco.mapping.kdtree.KDTreeOccupancy` override this.
-        """
-        return 0.0
+    clearance: float = 0.0
 
     @abstractmethod
     def nearest_obstacle(self, point: np.ndarray) -> Tuple[float, np.ndarray]:

--- a/src/arco/mapping/occupancy.py
+++ b/src/arco/mapping/occupancy.py
@@ -16,7 +16,20 @@ class Occupancy(Graph, ABC):
     Inherits from Graph, so planners can treat occupancy maps as graphs.
     Subclasses may use point clouds, kd-trees, etc.
     Provides a unified interface for obstacle queries in continuous space.
+
+    Optional clearance / batch-distance hooks default to conservative
+    fallbacks so pruner and optimizer code can call them without
+    ``getattr`` / ``hasattr`` branching.
     """
+
+    @property
+    def clearance(self) -> float:
+        """Minimum free margin around obstacles (meters).
+
+        Defaults to ``0.0`` (binary occupancy only).  Concrete maps such as
+        :class:`~arco.mapping.kdtree.KDTreeOccupancy` override this.
+        """
+        return 0.0
 
     @abstractmethod
     def nearest_obstacle(self, point: np.ndarray) -> Tuple[float, np.ndarray]:
@@ -41,3 +54,49 @@ class Occupancy(Graph, ABC):
         Returns:
             True if the point is occupied, False otherwise.
         """
+
+    def query_distances(self, points: np.ndarray) -> np.ndarray:
+        """Return nearest-obstacle distances for each row of *points*.
+
+        Default implementation loops over :meth:`nearest_obstacle`.
+        Subclasses may override with a batch query.
+
+        Args:
+            points: Array of shape ``(N, D)`` query positions.
+
+        Returns:
+            Array of shape ``(N,)`` distances.
+        """
+        pts = np.asarray(points, dtype=float)
+        if pts.ndim == 1:
+            pts = pts.reshape(1, -1)
+        return np.asarray(
+            [self.nearest_obstacle(p)[0] for p in pts], dtype=float
+        )
+
+    def segment_free(
+        self,
+        a: np.ndarray,
+        b: np.ndarray,
+        *,
+        sample_count: int = 12,
+    ) -> bool:
+        """Return True if the segment from *a* to *b* is collision-free.
+
+        Default policy matches historical RRT*/SST checking: linspace
+        *sample_count* points and test each with :meth:`is_occupied`.
+
+        Args:
+            a: Segment start.
+            b: Segment end.
+            sample_count: Number of sample points including endpoints.
+
+        Returns:
+            True when every sample is free.
+        """
+        count = max(int(sample_count), 2)
+        for t in np.linspace(0.0, 1.0, count):
+            pt = a + t * (b - a)
+            if self.is_occupied(pt):
+                return False
+        return True

--- a/src/arco/planning/__init__.py
+++ b/src/arco/planning/__init__.py
@@ -8,6 +8,7 @@ from .continuous import (
     TrajectoryPruner,
     TrajectoryResult,
 )
+from .cost import PlannerCost
 from .discrete import (
     AStar,
     AStarPlanner,
@@ -27,6 +28,7 @@ __all__ = [
     "DStarPlanner",
     "DiscretePlanner",
     "PipelineResult",
+    "PlannerCost",
     "PlanningPipeline",
     "RRTPlanner",
     "RouteResult",

--- a/src/arco/planning/continuous/__init__.py
+++ b/src/arco/planning/continuous/__init__.py
@@ -9,6 +9,7 @@ from .telemetry import (
     DEFAULT_TELEMETRY_PATH,
     PlannerTelemetry,
     StopCriterion,
+    noop_publisher,
     read_telemetry,
     write_telemetry,
 )
@@ -23,6 +24,7 @@ __all__ = [
     "TrajectoryOptimizer",
     "TrajectoryPruner",
     "TrajectoryResult",
+    "noop_publisher",
     "read_telemetry",
     "write_telemetry",
 ]

--- a/src/arco/planning/continuous/__init__.py
+++ b/src/arco/planning/continuous/__init__.py
@@ -12,3 +12,17 @@ from .telemetry import (
     read_telemetry,
     write_telemetry,
 )
+
+__all__ = [
+    "ContinuousPlanner",
+    "DEFAULT_TELEMETRY_PATH",
+    "PlannerTelemetry",
+    "RRTPlanner",
+    "SSTPlanner",
+    "StopCriterion",
+    "TrajectoryOptimizer",
+    "TrajectoryPruner",
+    "TrajectoryResult",
+    "read_telemetry",
+    "write_telemetry",
+]

--- a/src/arco/planning/continuous/base.py
+++ b/src/arco/planning/continuous/base.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, List, Optional
+from typing import Any, Callable, List, Optional
 
 import numpy as np
 
 from arco.mapping.occupancy import Occupancy
+from arco.planning.continuous.telemetry import (
+    PlannerTelemetry,
+    write_telemetry,
+)
 from arco.planning.cost import PlannerCost
+
+TelemetryFn = Callable[[PlannerTelemetry], None]
 
 
 class ContinuousPlanner(PlannerCost, ABC):
@@ -24,6 +30,10 @@ class ContinuousPlanner(PlannerCost, ABC):
     subclassing the algorithm.  When ``None`` (default), the planner uses
     its own distance/heuristic methods.
 
+    Optional ``publisher=``, ``seed=``, and ``rng=`` control telemetry
+    sinks and sampling reproducibility.  Defaults preserve historical
+    file-telemetry and unseeded RNG behavior.
+
     Subclasses must implement :meth:`plan`.
     """
 
@@ -31,6 +41,9 @@ class ContinuousPlanner(PlannerCost, ABC):
         self,
         occupancy: Occupancy,
         cost: Optional[PlannerCost] = None,
+        publisher: Optional[TelemetryFn] = None,
+        seed: Optional[int] = None,
+        rng: Optional[np.random.Generator] = None,
     ) -> None:
         """Initialize the planner with an occupancy map.
 
@@ -38,9 +51,21 @@ class ContinuousPlanner(PlannerCost, ABC):
             occupancy: The occupancy map for collision checking.
             cost: Optional external cost model.  When provided,
                 :meth:`distance` and :meth:`heuristic` delegate to it.
+            publisher: Optional telemetry sink.  When ``None``, snapshots
+                are written with
+                :func:`~arco.planning.continuous.telemetry.write_telemetry`.
+                Pass
+                :func:`~arco.planning.continuous.telemetry.noop_publisher`
+                to disable IPC.
+            seed: Optional RNG seed used when *rng* is not provided.
+            rng: Optional NumPy generator.  When set, takes precedence over
+                *seed*.
         """
         self.occupancy = occupancy
         self._cost_model = cost
+        self._telemetry_publisher = publisher
+        self._seed = seed
+        self._rng = rng
 
     def distance(self, state_a: Any, state_b: Any) -> float:
         """Return step-size-normalized Euclidean distance.
@@ -75,6 +100,27 @@ class ContinuousPlanner(PlannerCost, ABC):
         if self._cost_model is not None:
             return float(self._cost_model.heuristic(state_a, state_b))
         return self.distance(state_a, state_b)
+
+    def publish_telemetry(self, telemetry: PlannerTelemetry) -> None:
+        """Publish a telemetry snapshot via the configured sink.
+
+        Args:
+            telemetry: Snapshot to publish.
+        """
+        if self._telemetry_publisher is not None:
+            self._telemetry_publisher(telemetry)
+        else:
+            write_telemetry(telemetry)
+
+    def make_rng(self) -> np.random.Generator:
+        """Return the configured RNG (or a seeded/unseeded default).
+
+        Returns:
+            A :class:`numpy.random.Generator` instance.
+        """
+        if self._rng is not None:
+            return self._rng
+        return np.random.default_rng(self._seed)
 
     @abstractmethod
     def plan(

--- a/src/arco/planning/continuous/base.py
+++ b/src/arco/planning/continuous/base.py
@@ -8,10 +8,17 @@ from typing import Any, List, Optional
 import numpy as np
 
 from arco.mapping.occupancy import Occupancy
+from arco.planning.cost import PlannerCost
 
 
-class ContinuousPlanner(ABC):
+class ContinuousPlanner(PlannerCost, ABC):
     """Base class for planners operating in continuous state spaces.
+
+    Inherits :meth:`~arco.planning.cost.PlannerCost.distance` and
+    :meth:`~arco.planning.cost.PlannerCost.heuristic` from
+    :class:`~arco.planning.cost.PlannerCost`.  :meth:`distance` is
+    overridden to use step-size-normalized Euclidean distance once a
+    subclass sets :attr:`step_size`.
 
     Subclasses must implement :meth:`plan`.
     """
@@ -23,6 +30,25 @@ class ContinuousPlanner(ABC):
             occupancy: The occupancy map for collision checking.
         """
         self.occupancy = occupancy
+
+    def distance(self, state_a: Any, state_b: Any) -> float:
+        """Return step-size-normalized Euclidean distance.
+
+        Each axis is divided by the corresponding entry of
+        :attr:`step_size` (default ``1.0``) before the L2 norm is taken,
+        so mixed units across dimensions are handled uniformly.
+
+        Args:
+            state_a: Origin state.
+            state_b: Destination state.
+
+        Returns:
+            Non-negative normalized distance.
+        """
+        step = np.asarray(getattr(self, "step_size", 1.0), dtype=float)
+        a = np.asarray(state_a, dtype=float).reshape(-1)
+        b = np.asarray(state_b, dtype=float).reshape(-1)
+        return float(np.linalg.norm((b - a) / step))
 
     @abstractmethod
     def plan(

--- a/src/arco/planning/continuous/base.py
+++ b/src/arco/planning/continuous/base.py
@@ -20,23 +20,33 @@ class ContinuousPlanner(PlannerCost, ABC):
     overridden to use step-size-normalized Euclidean distance once a
     subclass sets :attr:`step_size`.
 
+    Pass ``cost=`` to compose an external :class:`PlannerCost` without
+    subclassing the algorithm.  When ``None`` (default), the planner uses
+    its own distance/heuristic methods.
+
     Subclasses must implement :meth:`plan`.
     """
 
-    def __init__(self, occupancy: Occupancy) -> None:
+    def __init__(
+        self,
+        occupancy: Occupancy,
+        cost: Optional[PlannerCost] = None,
+    ) -> None:
         """Initialize the planner with an occupancy map.
 
         Args:
             occupancy: The occupancy map for collision checking.
+            cost: Optional external cost model.  When provided,
+                :meth:`distance` and :meth:`heuristic` delegate to it.
         """
         self.occupancy = occupancy
+        self._cost_model = cost
 
     def distance(self, state_a: Any, state_b: Any) -> float:
         """Return step-size-normalized Euclidean distance.
 
-        Each axis is divided by the corresponding entry of
-        :attr:`step_size` (default ``1.0``) before the L2 norm is taken,
-        so mixed units across dimensions are handled uniformly.
+        When an external ``cost`` model was provided at construction,
+        delegates to that model instead.
 
         Args:
             state_a: Origin state.
@@ -45,10 +55,26 @@ class ContinuousPlanner(PlannerCost, ABC):
         Returns:
             Non-negative normalized distance.
         """
+        if self._cost_model is not None:
+            return float(self._cost_model.distance(state_a, state_b))
         step = np.asarray(getattr(self, "step_size", 1.0), dtype=float)
         a = np.asarray(state_a, dtype=float).reshape(-1)
         b = np.asarray(state_b, dtype=float).reshape(-1)
         return float(np.linalg.norm((b - a) / step))
+
+    def heuristic(self, state_a: Any, state_b: Any) -> float:
+        """Return remaining-cost estimate, honoring an external cost model.
+
+        Args:
+            state_a: Current state.
+            state_b: Goal state.
+
+        Returns:
+            Heuristic cost estimate.
+        """
+        if self._cost_model is not None:
+            return float(self._cost_model.heuristic(state_a, state_b))
+        return self.distance(state_a, state_b)
 
     @abstractmethod
     def plan(

--- a/src/arco/planning/continuous/cost_terms.py
+++ b/src/arco/planning/continuous/cost_terms.py
@@ -1,0 +1,302 @@
+"""Default CostTerm helpers for :class:`TrajectoryOptimizer`.
+
+These related classes share one optimization context contract and together
+reproduce the historical five-term composite cost (time, deviation,
+velocity, collision+barrier, dynamics).  They are kept in one module
+because they are tightly coupled to that shared context and the default
+term list factory.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from arco.protocols import CostTerm
+
+
+class TimeCostTerm:
+    """Penalize total traversal time squared: ``w · T²``.
+
+    Args:
+        weight: Multiplier for the squared total duration.
+    """
+
+    name: str = "time"
+
+    def __init__(self, weight: float) -> None:
+        """Initialize the time cost term.
+
+        Args:
+            weight: Multiplier for the squared total duration.
+        """
+        self.weight = float(weight)
+
+    def __call__(self, context: Dict[str, Any]) -> float:
+        """Evaluate the time cost.
+
+        Args:
+            context: Optimization context; requires ``durs``.
+
+        Returns:
+            Weighted squared total duration.
+        """
+        durs = context["durs"]
+        total_time = float(np.sum(durs))
+        return self.weight * total_time**2
+
+
+class DeviationCostTerm:
+    """Penalize squared deviation of interior waypoints from the reference.
+
+    Args:
+        weight: Multiplier for the summed squared deviation.
+    """
+
+    name: str = "deviation"
+
+    def __init__(self, weight: float) -> None:
+        """Initialize the deviation cost term.
+
+        Args:
+            weight: Multiplier for the summed squared deviation.
+        """
+        self.weight = float(weight)
+
+    def __call__(self, context: Dict[str, Any]) -> float:
+        """Evaluate the path-deviation cost.
+
+        Args:
+            context: Optimization context; requires ``pts``, ``ref``, and
+                ``segment_count``.
+
+        Returns:
+            Weighted sum of squared interior deviations, or ``0.0`` when
+            there are no interior waypoints.
+        """
+        segment_count = int(context["segment_count"])
+        interior_count = segment_count - 1
+        if interior_count <= 0:
+            return 0.0
+        pts = context["pts"]
+        ref = context["ref"]
+        ref_interior = np.array(ref[1:-1])
+        pts_interior = pts[1:-1]
+        return self.weight * float(np.sum((pts_interior - ref_interior) ** 2))
+
+
+class VelocityCostTerm:
+    """Penalize squared deviation of segment speeds from cruise speed.
+
+    Args:
+        weight: Multiplier for the summed squared speed error.
+        cruise_speed: Target traversal speed (world units / s).
+    """
+
+    name: str = "velocity"
+
+    def __init__(self, weight: float, cruise_speed: float) -> None:
+        """Initialize the velocity cost term.
+
+        Args:
+            weight: Multiplier for the summed squared speed error.
+            cruise_speed: Target traversal speed (world units / s).
+        """
+        self.weight = float(weight)
+        self.cruise_speed = float(cruise_speed)
+
+    def __call__(self, context: Dict[str, Any]) -> float:
+        """Evaluate the velocity-tracking cost.
+
+        Args:
+            context: Optimization context; requires ``speeds``.
+
+        Returns:
+            Weighted sum of squared ``(speed − cruise)`` errors.
+        """
+        speeds = context["speeds"]
+        return self.weight * float(np.sum((speeds - self.cruise_speed) ** 2))
+
+
+class CollisionCostTerm:
+    """Soft clearance penalty plus barrier-style penetration growth.
+
+    Combines the quadratic clearance violation with the scaled barrier
+    term used historically inside ``TrajectoryOptimizer._cost``.
+
+    Args:
+        weight: Multiplier applied to both soft and barrier penalties.
+        barrier_scale: Extra multiplier for the barrier contribution.
+        barrier_power: Exponent on normalized penetration depth.
+    """
+
+    name: str = "collision"
+
+    def __init__(
+        self,
+        weight: float,
+        barrier_scale: float = 50.0,
+        barrier_power: float = 4.0,
+    ) -> None:
+        """Initialize the collision cost term.
+
+        Args:
+            weight: Multiplier applied to both soft and barrier penalties.
+            barrier_scale: Extra multiplier for the barrier contribution.
+            barrier_power: Exponent on normalized penetration depth.
+        """
+        self.weight = float(weight)
+        self.barrier_scale = float(barrier_scale)
+        self.barrier_power = float(barrier_power)
+
+    def __call__(self, context: Dict[str, Any]) -> float:
+        """Evaluate soft collision plus barrier penalties.
+
+        Args:
+            context: Optimization context; requires ``pts``,
+                ``segment_count``, ``occupancy``, and ``sample_count``.
+
+        Returns:
+            Sum of the soft clearance penalty and the barrier penalty.
+        """
+        pts = context["pts"]
+        segment_count = int(context["segment_count"])
+        occupancy = context["occupancy"]
+        sample_count = int(context["sample_count"])
+        interior_count = segment_count - 1
+
+        clearance = getattr(occupancy, "clearance", 0.5)
+        j_collision = 0.0
+        j_collision_barrier = 0.0
+
+        query_pts_list: list[np.ndarray] = []
+        if interior_count > 0:
+            query_pts_list.append(pts[1:-1])
+
+        if sample_count > 0:
+            for i in range(segment_count):
+                p_a = pts[i]
+                p_b = pts[i + 1]
+                alphas = np.linspace(0.0, 1.0, sample_count + 2)[1:-1]
+                samples = p_a + alphas[:, None] * (p_b - p_a)
+                query_pts_list.append(samples)
+
+        if query_pts_list:
+            all_query = np.concatenate(query_pts_list, axis=0)
+            if hasattr(occupancy, "query_distances"):
+                dists = occupancy.query_distances(all_query)
+            else:
+                dists = np.array(
+                    [occupancy.nearest_obstacle(p)[0] for p in all_query]
+                )
+            penetrations = np.maximum(0.0, clearance - dists)
+            j_collision = self.weight * float(np.sum(penetrations**2))
+            clearance_safe = max(float(clearance), 1e-9)
+            normalized_penetrations = penetrations / clearance_safe
+            j_collision_barrier = (
+                self.weight
+                * self.barrier_scale
+                * float(np.sum(normalized_penetrations**self.barrier_power))
+            )
+
+        return j_collision + j_collision_barrier
+
+
+class DynamicsCostTerm:
+    """Penalize implied segment speeds outside ``[min_speed, max_speed]``.
+
+    Args:
+        weight: Multiplier for the summed squared bound violations.
+        max_speed: Optional upper speed limit (world units / s).
+        min_speed: Optional lower speed limit (world units / s).
+    """
+
+    name: str = "dynamics"
+
+    def __init__(
+        self,
+        weight: float,
+        max_speed: Optional[float] = None,
+        min_speed: Optional[float] = None,
+    ) -> None:
+        """Initialize the dynamics cost term.
+
+        Args:
+            weight: Multiplier for the summed squared bound violations.
+            max_speed: Optional upper speed limit (world units / s).
+            min_speed: Optional lower speed limit (world units / s).
+        """
+        self.weight = float(weight)
+        self.max_speed = max_speed
+        self.min_speed = min_speed
+
+    def __call__(self, context: Dict[str, Any]) -> float:
+        """Evaluate the dynamics-bound penalty.
+
+        Args:
+            context: Optimization context; requires ``speeds``.
+
+        Returns:
+            Weighted sum of squared speed-bound violations, or ``0.0``
+            when both bounds are unset.
+        """
+        if self.max_speed is None and self.min_speed is None:
+            return 0.0
+        speeds = context["speeds"]
+        j_dynamics = 0.0
+        if self.max_speed is not None:
+            over = np.maximum(0.0, speeds - self.max_speed)
+            j_dynamics += float(np.sum(over**2))
+        if self.min_speed is not None:
+            under = np.maximum(0.0, self.min_speed - speeds)
+            j_dynamics += float(np.sum(under**2))
+        return j_dynamics * self.weight
+
+
+def build_default_cost_terms(
+    *,
+    weight_time: float,
+    weight_deviation: float,
+    weight_velocity: float,
+    weight_collision: float,
+    weight_dynamics: float,
+    cruise_speed: float,
+    collision_barrier_scale: float,
+    collision_barrier_power: float,
+    max_speed: Optional[float],
+    min_speed: Optional[float],
+) -> List[CostTerm]:
+    """Build the five historical default optimizer cost terms.
+
+    Args:
+        weight_time: Weight for the total-time-squared term.
+        weight_deviation: Weight for interior path deviation.
+        weight_velocity: Weight for cruise-speed tracking.
+        weight_collision: Weight for clearance / barrier penalties.
+        weight_dynamics: Weight for speed-bound penalties.
+        cruise_speed: Target traversal speed (world units / s).
+        collision_barrier_scale: Barrier multiplier on clearance violations.
+        collision_barrier_power: Barrier exponent on normalized penetration.
+        max_speed: Optional upper speed limit for the dynamics term.
+        min_speed: Optional lower speed limit for the dynamics term.
+
+    Returns:
+        Ordered list of five :class:`~arco.protocols.CostTerm` instances
+        matching historical ``_cost`` composition order.
+    """
+    return [
+        TimeCostTerm(weight_time),
+        DeviationCostTerm(weight_deviation),
+        VelocityCostTerm(weight_velocity, cruise_speed),
+        CollisionCostTerm(
+            weight_collision,
+            barrier_scale=collision_barrier_scale,
+            barrier_power=collision_barrier_power,
+        ),
+        DynamicsCostTerm(
+            weight_dynamics,
+            max_speed=max_speed,
+            min_speed=min_speed,
+        ),
+    ]

--- a/src/arco/planning/continuous/optimizer.py
+++ b/src/arco/planning/continuous/optimizer.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from typing import Callable, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 from scipy.optimize import minimize
 
 from arco.config import load_config
 from arco.mapping.occupancy import Occupancy
+from arco.planning.continuous.cost_terms import build_default_cost_terms
+from arco.protocols import CostTerm
 
 
 @dataclass
@@ -138,6 +140,11 @@ class TrajectoryOptimizer:
         max_iter: Maximum number of iterations for the Stage-2 solver.
         ftol: Convergence tolerance for the Stage-2 solver (function
             value change threshold).
+        cost_terms: Optional ordered list of
+            :class:`~arco.protocols.CostTerm` callables.  When ``None``,
+            the five historical defaults (time, deviation, velocity,
+            collision+barrier, dynamics) are built from the weight
+            arguments above.
 
     Raises:
         ValueError: If *cruise_speed* is not positive.
@@ -242,6 +249,7 @@ class TrajectoryOptimizer:
         sample_count: int = 3,
         max_iter: int = 500,
         ftol: float = 1e-9,
+        cost_terms: Optional[Sequence[CostTerm]] = None,
     ) -> None:
         """Initialize the TrajectoryOptimizer.
 
@@ -273,6 +281,10 @@ class TrajectoryOptimizer:
                 collision term.
             max_iter: Maximum number of Stage-2 solver iterations.
             ftol: Stage-2 solver convergence tolerance (function value).
+            cost_terms: Optional ordered list of cost-term callables.
+                When ``None``, builds the five historical defaults from
+                the weight arguments.  Custom lists replace the defaults
+                entirely.
 
         Raises:
             ValueError: If *cruise_speed* is not positive.
@@ -297,6 +309,21 @@ class TrajectoryOptimizer:
         self.sample_count = sample_count
         self.max_iter = max_iter
         self.ftol = ftol
+        if cost_terms is None:
+            self.cost_terms: List[CostTerm] = build_default_cost_terms(
+                weight_time=weight_time,
+                weight_deviation=weight_deviation,
+                weight_velocity=weight_velocity,
+                weight_collision=weight_collision,
+                weight_dynamics=weight_dynamics,
+                cruise_speed=cruise_speed,
+                collision_barrier_scale=collision_barrier_scale,
+                collision_barrier_power=collision_barrier_power,
+                max_speed=max_speed,
+                min_speed=min_speed,
+            )
+        else:
+            self.cost_terms = list(cost_terms)
 
     # ------------------------------------------------------------------
     # Public API
@@ -472,6 +499,9 @@ class TrajectoryOptimizer:
     ) -> float:
         """Evaluate the composite cost function.
 
+        Builds a shared context dict and sums ``term(context)`` over
+        :attr:`cost_terms`.
+
         Args:
             x: Flat decision-variable vector (durations + interior
                 waypoint positions).
@@ -487,94 +517,38 @@ class TrajectoryOptimizer:
         # Build numpy arrays for vectorised computation
         pts = np.array(waypoints)  # (N+1, dim)
         durs = np.maximum(durations, 1e-9)  # (N,)
-
-        # --- Time cost ---------------------------------------------------
-        total_time = float(np.sum(durs))
-        j_time = self.weight_time * total_time**2
-
-        # --- Velocity deviation ------------------------------------------
         diff = pts[1:] - pts[:-1]  # (N, dim)
         lengths = np.linalg.norm(diff, axis=1)  # (N,)
         speeds = lengths / durs  # (N,)
-        j_velocity = self.weight_velocity * float(
-            np.sum((speeds - self.cruise_speed) ** 2)
-        )
 
-        # --- Deviation from reference path (interior only) ---------------
-        # Interior waypoints: indices 1 .. N-1
-        interior_count = segment_count - 1
-        j_deviation = 0.0
-        if interior_count > 0:
-            ref_interior = np.array(ref[1:-1])  # (N-1, dim)
-            pts_interior = pts[1:-1]  # (N-1, dim)
-            j_deviation = self.weight_deviation * float(
-                np.sum((pts_interior - ref_interior) ** 2)
-            )
+        context: Dict[str, Any] = {
+            "durations": durations,
+            "durs": durs,
+            "waypoints": waypoints,
+            "pts": pts,
+            "lengths": lengths,
+            "speeds": speeds,
+            "ref": ref,
+            "segment_count": segment_count,
+            "dim": dim,
+            "occupancy": self.occupancy,
+            "sample_count": self.sample_count,
+            "cruise_speed": self.cruise_speed,
+            "weight_time": self.weight_time,
+            "weight_deviation": self.weight_deviation,
+            "weight_velocity": self.weight_velocity,
+            "weight_collision": self.weight_collision,
+            "weight_dynamics": self.weight_dynamics,
+            "collision_barrier_scale": self.collision_barrier_scale,
+            "collision_barrier_power": self.collision_barrier_power,
+            "max_speed": self.max_speed,
+            "min_speed": self.min_speed,
+        }
 
-        # --- Collision penalty (batch query) -----------------------------
-        clearance = getattr(self.occupancy, "clearance", 0.5)
-        j_collision = 0.0
-        j_collision_barrier = 0.0
-
-        # Collect all query points: interior waypoints + segment samples
-        query_pts_list: list[np.ndarray] = []
-        if interior_count > 0:
-            query_pts_list.append(pts[1:-1])
-
-        if self.sample_count > 0:
-            for i in range(segment_count):
-                p_a = pts[i]
-                p_b = pts[i + 1]
-                alphas = np.linspace(0.0, 1.0, self.sample_count + 2)[1:-1]
-                samples = p_a + alphas[:, None] * (p_b - p_a)
-                query_pts_list.append(samples)
-
-        if query_pts_list:
-            all_query = np.concatenate(query_pts_list, axis=0)
-            # Use batch query when available (KDTreeOccupancy)
-            if hasattr(self.occupancy, "query_distances"):
-                dists = self.occupancy.query_distances(all_query)
-            else:
-                dists = np.array(
-                    [self.occupancy.nearest_obstacle(p)[0] for p in all_query]
-                )
-            penetrations = np.maximum(0.0, clearance - dists)
-            j_collision = self.weight_collision * float(
-                np.sum(penetrations**2)
-            )
-            clearance_safe = max(float(clearance), 1e-9)
-            normalized_penetrations = penetrations / clearance_safe
-            j_collision_barrier = (
-                self.weight_collision
-                * self.collision_barrier_scale
-                * float(
-                    np.sum(
-                        normalized_penetrations**self.collision_barrier_power
-                    )
-                )
-            )
-
-        # --- Dynamics penalty (speed bounds) -----------------------------
-        # Penalises implied segment speeds that violate max_speed / min_speed.
-        # Acts as a soft-to-hard barrier scaled by weight_dynamics.
-        j_dynamics = 0.0
-        if self.max_speed is not None or self.min_speed is not None:
-            if self.max_speed is not None:
-                over = np.maximum(0.0, speeds - self.max_speed)
-                j_dynamics += float(np.sum(over**2))
-            if self.min_speed is not None:
-                under = np.maximum(0.0, self.min_speed - speeds)
-                j_dynamics += float(np.sum(under**2))
-            j_dynamics *= self.weight_dynamics
-
-        return (
-            j_time
-            + j_deviation
-            + j_velocity
-            + j_collision
-            + j_collision_barrier
-            + j_dynamics
-        )
+        total = 0.0
+        for term in self.cost_terms:
+            total += float(term(context))
+        return total
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/arco/planning/continuous/pruner.py
+++ b/src/arco/planning/continuous/pruner.py
@@ -225,7 +225,7 @@ class TrajectoryPruner:
             from all obstacle points; ``False`` if any point violates the
             clearance constraint.
         """
-        clearance: float = getattr(self.occupancy, "clearance", 0.0)
+        clearance: float = float(self.occupancy.clearance)
 
         # --- Step-size criterion (primary) --------------------------------
         # D[i] / L[i] gives the number of planner steps spanned by this
@@ -253,10 +253,9 @@ class TrajectoryPruner:
         # Prefer the batch distance query for efficiency; the explicit
         # comparison `distances >= clearance` is the canonical
         # nearest + distance-thresholding check.
-        if clearance > 0.0 and hasattr(self.occupancy, "query_distances"):
+        if clearance > 0.0:
             distances = self.occupancy.query_distances(pts)
             return bool(np.all(distances >= clearance))
 
-        # Fallback for occupancy maps that only expose is_occupied().
-        # is_occupied() also performs nearest + distance thresholding.
+        # Fallback for binary occupancy maps (clearance == 0).
         return all(not self.occupancy.is_occupied(pt) for pt in pts)

--- a/src/arco/planning/continuous/rrt.py
+++ b/src/arco/planning/continuous/rrt.py
@@ -589,9 +589,8 @@ class RRTPlanner(ContinuousPlanner):
     def _segment_free(self, a: np.ndarray, b: np.ndarray) -> bool:
         """Check whether the straight-line segment from *a* to *b* is free.
 
-        Discretizes the segment into :attr:`collision_check_count`
-        intermediate points and tests each with
-        :meth:`~arco.mapping.Occupancy.is_occupied`.
+        Delegates to :meth:`~arco.mapping.occupancy.Occupancy.segment_free`
+        with ``collision_check_count + 2`` samples (historical RRT* density).
 
         Args:
             a: Segment start position.
@@ -600,11 +599,9 @@ class RRTPlanner(ContinuousPlanner):
         Returns:
             True if no intermediate point is occupied, False otherwise.
         """
-        for t in np.linspace(0.0, 1.0, self.collision_check_count + 2):
-            pt = a + t * (b - a)
-            if self.occupancy.is_occupied(pt):
-                return False
-        return True
+        return self.occupancy.segment_free(
+            a, b, sample_count=self.collision_check_count + 2
+        )
 
     def _extract_path(
         self,

--- a/src/arco/planning/continuous/rrt.py
+++ b/src/arco/planning/continuous/rrt.py
@@ -9,6 +9,7 @@ from typing import Callable, Dict, List, Optional, Sequence, Tuple
 import numpy as np
 
 from arco.mapping.occupancy import Occupancy
+from arco.planning.cost import PlannerCost
 
 from .base import ContinuousPlanner
 from .telemetry import (
@@ -82,6 +83,7 @@ class RRTPlanner(ContinuousPlanner):
         sampler: Optional[SamplerFn] = None,
         steerer: Optional[SteererFn] = None,
         segment_free: Optional[SegmentFreeFn] = None,
+        cost: Optional[PlannerCost] = None,
     ) -> None:
         """Initialize RRTPlanner.
 
@@ -111,12 +113,14 @@ class RRTPlanner(ContinuousPlanner):
                 here for kinodynamic expansion.
             segment_free: Optional ``(a, b) -> bool`` collision override.
                 Defaults to linspace point checks via ``occupancy.is_occupied``.
+            cost: Optional external :class:`~arco.planning.cost.PlannerCost`.
+                When ``None``, uses this planner's step-normalized distance.
 
         Raises:
             ValueError: If *bounds* is empty or any element of *step_size*
                 is not positive.
         """
-        super().__init__(occupancy)
+        super().__init__(occupancy, cost=cost)
         if not bounds:
             raise ValueError("bounds must not be empty.")
         self.step_size = np.asarray(step_size, dtype=float)

--- a/src/arco/planning/continuous/rrt.py
+++ b/src/arco/planning/continuous/rrt.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -18,6 +18,10 @@ from .telemetry import (
     StopCriterion,
     write_telemetry,
 )
+
+SamplerFn = Callable[[np.random.Generator], np.ndarray]
+SteererFn = Callable[[np.ndarray, np.ndarray], np.ndarray]
+SegmentFreeFn = Callable[[np.ndarray, np.ndarray], bool]
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +79,9 @@ class RRTPlanner(ContinuousPlanner):
         collision_check_count: int = 10,
         goal_bias: float = 0.05,
         early_stop: bool = True,
+        sampler: Optional[SamplerFn] = None,
+        steerer: Optional[SteererFn] = None,
+        segment_free: Optional[SegmentFreeFn] = None,
     ) -> None:
         """Initialize RRTPlanner.
 
@@ -96,6 +103,14 @@ class RRTPlanner(ContinuousPlanner):
             goal_bias: Probability of sampling the goal directly.
             early_stop: If ``True``, stop at the first node that reaches the
                 goal.  If ``False``, run all iterations to optimize cost.
+            sampler: Optional ``(rng) -> state`` override.  Defaults to
+                uniform sampling in *bounds*.
+            steerer: Optional ``(from, to) -> state`` override.  Defaults to
+                step-size-limited straight-line steering.  Wrap an
+                :class:`~arco.guidance.primitive.base.ExplorationPrimitive`
+                here for kinodynamic expansion.
+            segment_free: Optional ``(a, b) -> bool`` collision override.
+                Defaults to linspace point checks via ``occupancy.is_occupied``.
 
         Raises:
             ValueError: If *bounds* is empty or any element of *step_size*
@@ -115,6 +130,9 @@ class RRTPlanner(ContinuousPlanner):
         self.goal_bias = goal_bias
         self.early_stop = early_stop
         self._dim = len(bounds)
+        self._sampler_override = sampler
+        self._steerer_override = steerer
+        self._segment_free_override = segment_free
 
     # ------------------------------------------------------------------
     # Public API
@@ -186,17 +204,17 @@ class RRTPlanner(ContinuousPlanner):
             if rng.random() < self.goal_bias:
                 x_rand = goal.copy()
             else:
-                x_rand = self._sample(rng)
+                x_rand = self.sample(rng)
 
             # --- Nearest --------------------------------------------------
             nearest_idx = self._nearest(nodes, x_rand)
             x_nearest = nodes[nearest_idx]
 
             # --- Steer ----------------------------------------------------
-            x_new = self._steer(x_nearest, x_rand)
+            x_new = self.steer(x_nearest, x_rand)
 
             # --- Collision check on edge ---------------------------------
-            if not self._segment_free(x_nearest, x_new):
+            if not self.is_segment_free(x_nearest, x_new):
                 continue
 
             # --- Near nodes -----------------------------------------------
@@ -211,7 +229,7 @@ class RRTPlanner(ContinuousPlanner):
                 if idx == nearest_idx:
                     continue
                 c = cost[idx] + self.distance(nodes[idx], x_new)
-                if c < best_cost and self._segment_free(nodes[idx], x_new):
+                if c < best_cost and self.is_segment_free(nodes[idx], x_new):
                     best_cost = c
                     best_parent_idx = idx
 
@@ -226,7 +244,7 @@ class RRTPlanner(ContinuousPlanner):
                 if idx == best_parent_idx:
                     continue
                 c_through_new = best_cost + self.distance(x_new, nodes[idx])
-                if c_through_new < cost[idx] and self._segment_free(
+                if c_through_new < cost[idx] and self.is_segment_free(
                     x_new, nodes[idx]
                 ):
                     parent[idx] = new_idx
@@ -260,7 +278,7 @@ class RRTPlanner(ContinuousPlanner):
         # node may be far enough from the goal that the connecting segment
         # crosses an obstacle — skipping this check is Bug 1 of the city
         # scenario.
-        if self._segment_free(nodes[best_goal_node], goal):
+        if self.is_segment_free(nodes[best_goal_node], goal):
             path.append(goal.copy())
         logger.debug(
             "RRT*: path extracted, %d waypoints, cost=%.3f",
@@ -342,13 +360,13 @@ class RRTPlanner(ContinuousPlanner):
             if rng.random() < self.goal_bias:
                 x_rand = goal.copy()
             else:
-                x_rand = self._sample(rng)
+                x_rand = self.sample(rng)
 
             nearest_idx = self._nearest(nodes, x_rand)
             x_nearest = nodes[nearest_idx]
-            x_new = self._steer(x_nearest, x_rand)
+            x_new = self.steer(x_nearest, x_rand)
 
-            if not self._segment_free(x_nearest, x_new):
+            if not self.is_segment_free(x_nearest, x_new):
                 continue
 
             node_count = len(nodes)
@@ -361,7 +379,7 @@ class RRTPlanner(ContinuousPlanner):
                 if idx == nearest_idx:
                     continue
                 c = cost[idx] + self.distance(nodes[idx], x_new)
-                if c < best_cost and self._segment_free(nodes[idx], x_new):
+                if c < best_cost and self.is_segment_free(nodes[idx], x_new):
                     best_cost = c
                     best_parent_idx = idx
 
@@ -374,7 +392,7 @@ class RRTPlanner(ContinuousPlanner):
                 if idx == best_parent_idx:
                     continue
                 c_through_new = best_cost + self.distance(x_new, nodes[idx])
-                if c_through_new < cost[idx] and self._segment_free(
+                if c_through_new < cost[idx] and self.is_segment_free(
                     x_new, nodes[idx]
                 ):
                     parent[idx] = new_idx
@@ -399,13 +417,54 @@ class RRTPlanner(ContinuousPlanner):
         # Only append the exact goal when the direct segment is free (same
         # fix as in plan() — large goal_tolerance allows the last tree node
         # to be far enough for the segment to cross an obstacle).
-        if self._segment_free(nodes[best_goal_node], goal):
+        if self.is_segment_free(nodes[best_goal_node], goal):
             path.append(goal.copy())
         return nodes, parent, path
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def sample(self, rng: np.random.Generator) -> np.ndarray:
+        """Sample a state, honoring an optional constructor override.
+
+        Args:
+            rng: NumPy random generator.
+
+        Returns:
+            A sampled state array.
+        """
+        if self._sampler_override is not None:
+            return self._sampler_override(rng)
+        return self._sample(rng)
+
+    def steer(self, from_pt: np.ndarray, to_pt: np.ndarray) -> np.ndarray:
+        """Steer toward a target, honoring an optional constructor override.
+
+        Args:
+            from_pt: Origin state.
+            to_pt: Target state.
+
+        Returns:
+            New state after one steering step.
+        """
+        if self._steerer_override is not None:
+            return self._steerer_override(from_pt, to_pt)
+        return self._steer(from_pt, to_pt)
+
+    def is_segment_free(self, a: np.ndarray, b: np.ndarray) -> bool:
+        """Check segment clearance, honoring an optional override.
+
+        Args:
+            a: Segment start.
+            b: Segment end.
+
+        Returns:
+            True if the segment is considered collision-free.
+        """
+        if self._segment_free_override is not None:
+            return bool(self._segment_free_override(a, b))
+        return self._segment_free(a, b)
 
     def _sample(self, rng: np.random.Generator) -> np.ndarray:
         """Sample a random point uniformly within :attr:`bounds`.

--- a/src/arco/planning/continuous/rrt.py
+++ b/src/arco/planning/continuous/rrt.py
@@ -17,7 +17,6 @@ from .telemetry import (
     TELEMETRY_WRITE_INTERVAL,
     PlannerTelemetry,
     StopCriterion,
-    write_telemetry,
 )
 
 SamplerFn = Callable[[np.random.Generator], np.ndarray]
@@ -84,6 +83,9 @@ class RRTPlanner(ContinuousPlanner):
         steerer: Optional[SteererFn] = None,
         segment_free: Optional[SegmentFreeFn] = None,
         cost: Optional[PlannerCost] = None,
+        publisher: Optional[Callable[[PlannerTelemetry], None]] = None,
+        seed: Optional[int] = None,
+        rng: Optional[np.random.Generator] = None,
     ) -> None:
         """Initialize RRTPlanner.
 
@@ -115,12 +117,22 @@ class RRTPlanner(ContinuousPlanner):
                 Defaults to linspace point checks via ``occupancy.is_occupied``.
             cost: Optional external :class:`~arco.planning.cost.PlannerCost`.
                 When ``None``, uses this planner's step-normalized distance.
+            publisher: Optional telemetry sink.  Defaults to file IPC via
+                :func:`~arco.planning.continuous.telemetry.write_telemetry`.
+            seed: Optional RNG seed when *rng* is omitted.
+            rng: Optional NumPy generator (overrides *seed*).
 
         Raises:
             ValueError: If *bounds* is empty or any element of *step_size*
                 is not positive.
         """
-        super().__init__(occupancy, cost=cost)
+        super().__init__(
+            occupancy,
+            cost=cost,
+            publisher=publisher,
+            seed=seed,
+            rng=rng,
+        )
         if not bounds:
             raise ValueError("bounds must not be empty.")
         self.step_size = np.asarray(step_size, dtype=float)
@@ -176,12 +188,12 @@ class RRTPlanner(ContinuousPlanner):
         best_goal_cost = math.inf
         _best_dist_to_goal = math.inf
 
-        rng = np.random.default_rng()
+        rng = self.make_rng()
 
         for iteration in range(self.max_sample_count):
             # --- Telemetry ------------------------------------------------
             if iteration % TELEMETRY_WRITE_INTERVAL == 0:
-                write_telemetry(
+                self.publish_telemetry(
                     PlannerTelemetry(
                         algorithm="RRT*",
                         step_name="exploring",
@@ -334,11 +346,11 @@ class RRTPlanner(ContinuousPlanner):
         best_goal_cost = math.inf
         _best_dist_to_goal = math.inf
 
-        rng = np.random.default_rng()
+        rng = self.make_rng()
 
         for _iter in range(self.max_sample_count):
             if _iter % TELEMETRY_WRITE_INTERVAL == 0:
-                write_telemetry(
+                self.publish_telemetry(
                     PlannerTelemetry(
                         algorithm="RRT*",
                         step_name="exploring (tree)",

--- a/src/arco/planning/continuous/rrt.py
+++ b/src/arco/planning/continuous/rrt.py
@@ -206,15 +206,11 @@ class RRTPlanner(ContinuousPlanner):
 
             # --- Choose best parent --------------------------------------
             best_parent_idx = nearest_idx
-            best_cost = cost[nearest_idx] + float(
-                np.linalg.norm((x_new - x_nearest) / self.step_size)
-            )
+            best_cost = cost[nearest_idx] + self.distance(x_nearest, x_new)
             for idx in near_idxs:
                 if idx == nearest_idx:
                     continue
-                c = cost[idx] + float(
-                    np.linalg.norm((x_new - nodes[idx]) / self.step_size)
-                )
+                c = cost[idx] + self.distance(nodes[idx], x_new)
                 if c < best_cost and self._segment_free(nodes[idx], x_new):
                     best_cost = c
                     best_parent_idx = idx
@@ -229,9 +225,7 @@ class RRTPlanner(ContinuousPlanner):
             for idx in near_idxs:
                 if idx == best_parent_idx:
                     continue
-                c_through_new = best_cost + float(
-                    np.linalg.norm((nodes[idx] - x_new) / self.step_size)
-                )
+                c_through_new = best_cost + self.distance(x_new, nodes[idx])
                 if c_through_new < cost[idx] and self._segment_free(
                     x_new, nodes[idx]
                 ):
@@ -239,9 +233,7 @@ class RRTPlanner(ContinuousPlanner):
                     cost[idx] = c_through_new
 
             # --- Goal check -----------------------------------------------
-            dist_to_goal = float(
-                np.linalg.norm((x_new - goal) / self.step_size)
-            )
+            dist_to_goal = self.distance(x_new, goal)
             if dist_to_goal < _best_dist_to_goal:
                 _best_dist_to_goal = dist_to_goal
             if (
@@ -364,15 +356,11 @@ class RRTPlanner(ContinuousPlanner):
             near_idxs = self._near(nodes, x_new, radius)
 
             best_parent_idx = nearest_idx
-            best_cost = cost[nearest_idx] + float(
-                np.linalg.norm((x_new - x_nearest) / self.step_size)
-            )
+            best_cost = cost[nearest_idx] + self.distance(x_nearest, x_new)
             for idx in near_idxs:
                 if idx == nearest_idx:
                     continue
-                c = cost[idx] + float(
-                    np.linalg.norm((x_new - nodes[idx]) / self.step_size)
-                )
+                c = cost[idx] + self.distance(nodes[idx], x_new)
                 if c < best_cost and self._segment_free(nodes[idx], x_new):
                     best_cost = c
                     best_parent_idx = idx
@@ -385,18 +373,14 @@ class RRTPlanner(ContinuousPlanner):
             for idx in near_idxs:
                 if idx == best_parent_idx:
                     continue
-                c_through_new = best_cost + float(
-                    np.linalg.norm((nodes[idx] - x_new) / self.step_size)
-                )
+                c_through_new = best_cost + self.distance(x_new, nodes[idx])
                 if c_through_new < cost[idx] and self._segment_free(
                     x_new, nodes[idx]
                 ):
                     parent[idx] = new_idx
                     cost[idx] = c_through_new
 
-            dist_to_goal = float(
-                np.linalg.norm((x_new - goal) / self.step_size)
-            )
+            dist_to_goal = self.distance(x_new, goal)
             if dist_to_goal < _best_dist_to_goal:
                 _best_dist_to_goal = dist_to_goal
             if (
@@ -448,9 +432,7 @@ class RRTPlanner(ContinuousPlanner):
         Returns:
             Index of the nearest node in *nodes*.
         """
-        dists = [
-            float(np.linalg.norm((n - point) / self.step_size)) for n in nodes
-        ]
+        dists = [self.distance(n, point) for n in nodes]
         return int(np.argmin(dists))
 
     def _steer(self, from_pt: np.ndarray, to_pt: np.ndarray) -> np.ndarray:
@@ -468,7 +450,7 @@ class RRTPlanner(ContinuousPlanner):
             in normalized space.
         """
         delta = to_pt - from_pt
-        dist = float(np.linalg.norm(delta / self.step_size))
+        dist = self.distance(from_pt, to_pt)
         if dist <= 1.0:
             return to_pt.copy()
         return from_pt + delta / dist
@@ -478,7 +460,7 @@ class RRTPlanner(ContinuousPlanner):
     ) -> List[int]:
         """Return indices of all nodes within *radius* of *point*.
 
-        Distance is measured in the space normalized by :attr:`step_size`.
+        Distance is measured via :meth:`distance` (step-size-normalized).
 
         Args:
             nodes: Current tree nodes.
@@ -489,9 +471,7 @@ class RRTPlanner(ContinuousPlanner):
             List of node indices within the radius.
         """
         return [
-            i
-            for i, n in enumerate(nodes)
-            if float(np.linalg.norm((n - point) / self.step_size)) <= radius
+            i for i, n in enumerate(nodes) if self.distance(n, point) <= radius
         ]
 
     def _rewire_radius(self, node_count: int) -> float:

--- a/src/arco/planning/continuous/sst.py
+++ b/src/arco/planning/continuous/sst.py
@@ -9,6 +9,7 @@ from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple
 import numpy as np
 
 from arco.mapping.occupancy import Occupancy
+from arco.planning.cost import PlannerCost
 
 from .base import ContinuousPlanner
 from .telemetry import (
@@ -78,6 +79,7 @@ class SSTPlanner(ContinuousPlanner):
         sampler: Optional[SamplerFn] = None,
         steerer: Optional[SteererFn] = None,
         segment_free: Optional[SegmentFreeFn] = None,
+        cost: Optional[PlannerCost] = None,
     ) -> None:
         """Initialize SSTPlanner.
 
@@ -102,12 +104,14 @@ class SSTPlanner(ContinuousPlanner):
                 step-size-limited straight-line steering.
             segment_free: Optional ``(a, b) -> bool`` collision override.
                 Defaults to linspace point checks via ``occupancy.is_occupied``.
+            cost: Optional external :class:`~arco.planning.cost.PlannerCost`.
+                When ``None``, uses this planner's step-normalized distance.
 
         Raises:
             ValueError: If *bounds* is empty or any element of *step_size*
                 is not positive.
         """
-        super().__init__(occupancy)
+        super().__init__(occupancy, cost=cost)
         if not bounds:
             raise ValueError("bounds must not be empty.")
         self.step_size = np.asarray(step_size, dtype=float)

--- a/src/arco/planning/continuous/sst.py
+++ b/src/arco/planning/continuous/sst.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Dict, List, Optional, Sequence, Set, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 import numpy as np
 
@@ -17,6 +17,10 @@ from .telemetry import (
     StopCriterion,
     write_telemetry,
 )
+
+SamplerFn = Callable[[np.random.Generator], np.ndarray]
+SteererFn = Callable[[np.ndarray, np.ndarray], np.ndarray]
+SegmentFreeFn = Callable[[np.ndarray, np.ndarray], bool]
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +75,9 @@ class SSTPlanner(ContinuousPlanner):
         collision_check_count: int = 10,
         goal_bias: float = 0.05,
         early_stop: bool = True,
+        sampler: Optional[SamplerFn] = None,
+        steerer: Optional[SteererFn] = None,
+        segment_free: Optional[SegmentFreeFn] = None,
     ) -> None:
         """Initialize SSTPlanner.
 
@@ -89,6 +96,12 @@ class SSTPlanner(ContinuousPlanner):
             goal_bias: Probability of sampling the goal directly.
             early_stop: If ``True``, stop at the first node that reaches the
                 goal.  If ``False``, run all iterations to optimize cost.
+            sampler: Optional ``(rng) -> state`` override.  Defaults to
+                uniform sampling in *bounds*.
+            steerer: Optional ``(from, to) -> state`` override.  Defaults to
+                step-size-limited straight-line steering.
+            segment_free: Optional ``(a, b) -> bool`` collision override.
+                Defaults to linspace point checks via ``occupancy.is_occupied``.
 
         Raises:
             ValueError: If *bounds* is empty or any element of *step_size*
@@ -107,6 +120,9 @@ class SSTPlanner(ContinuousPlanner):
         self.collision_check_count = collision_check_count
         self.goal_bias = goal_bias
         self.early_stop = early_stop
+        self._sampler_override = sampler
+        self._steerer_override = steerer
+        self._segment_free_override = segment_free
 
     # ------------------------------------------------------------------
     # Public API
@@ -240,7 +256,7 @@ class SSTPlanner(ContinuousPlanner):
             if rng.random() < self.goal_bias:
                 x_rand = goal.copy()
             else:
-                x_rand = self._sample(rng)
+                x_rand = self.sample(rng)
 
             # --- Select nearest active node to sample --------------------
             # Geometric SST uses nearest-neighbor selection, which allows
@@ -251,10 +267,10 @@ class SSTPlanner(ContinuousPlanner):
             x_selected = nodes[x_selected_idx]
 
             # --- Propagate -----------------------------------------------
-            x_new = self._steer(x_selected, x_rand)
+            x_new = self.steer(x_selected, x_rand)
 
             # --- Collision check -----------------------------------------
-            if not self._segment_free(x_selected, x_new):
+            if not self.is_segment_free(x_selected, x_new):
                 continue
 
             new_cost = cost[x_selected_idx] + self.distance(x_selected, x_new)
@@ -315,7 +331,7 @@ class SSTPlanner(ContinuousPlanner):
         # Only append the exact goal when the direct segment is free.
         # Large goal_tolerance values allow the last tree node to be far
         # enough from the goal that the connecting segment crosses an obstacle.
-        if self._segment_free(nodes[best_goal_node], goal):
+        if self.is_segment_free(nodes[best_goal_node], goal):
             path.append(goal.copy())
         active_nodes, active_parent = self._build_active_output(
             nodes, parent, active
@@ -359,6 +375,47 @@ class SSTPlanner(ContinuousPlanner):
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def sample(self, rng: np.random.Generator) -> np.ndarray:
+        """Sample a state, honoring an optional constructor override.
+
+        Args:
+            rng: NumPy random generator.
+
+        Returns:
+            A sampled state array.
+        """
+        if self._sampler_override is not None:
+            return self._sampler_override(rng)
+        return self._sample(rng)
+
+    def steer(self, from_pt: np.ndarray, to_pt: np.ndarray) -> np.ndarray:
+        """Steer toward a target, honoring an optional constructor override.
+
+        Args:
+            from_pt: Origin state.
+            to_pt: Target state.
+
+        Returns:
+            New state after one steering step.
+        """
+        if self._steerer_override is not None:
+            return self._steerer_override(from_pt, to_pt)
+        return self._steer(from_pt, to_pt)
+
+    def is_segment_free(self, a: np.ndarray, b: np.ndarray) -> bool:
+        """Check segment clearance, honoring an optional override.
+
+        Args:
+            a: Segment start.
+            b: Segment end.
+
+        Returns:
+            True if the segment is considered collision-free.
+        """
+        if self._segment_free_override is not None:
+            return bool(self._segment_free_override(a, b))
+        return self._segment_free(a, b)
 
     def _sample(self, rng: np.random.Generator) -> np.ndarray:
         """Sample a random point uniformly within :attr:`bounds`.

--- a/src/arco/planning/continuous/sst.py
+++ b/src/arco/planning/continuous/sst.py
@@ -16,7 +16,6 @@ from .telemetry import (
     TELEMETRY_WRITE_INTERVAL,
     PlannerTelemetry,
     StopCriterion,
-    write_telemetry,
 )
 
 SamplerFn = Callable[[np.random.Generator], np.ndarray]
@@ -80,6 +79,9 @@ class SSTPlanner(ContinuousPlanner):
         steerer: Optional[SteererFn] = None,
         segment_free: Optional[SegmentFreeFn] = None,
         cost: Optional[PlannerCost] = None,
+        publisher: Optional[Callable[[PlannerTelemetry], None]] = None,
+        seed: Optional[int] = None,
+        rng: Optional[np.random.Generator] = None,
     ) -> None:
         """Initialize SSTPlanner.
 
@@ -106,12 +108,22 @@ class SSTPlanner(ContinuousPlanner):
                 Defaults to linspace point checks via ``occupancy.is_occupied``.
             cost: Optional external :class:`~arco.planning.cost.PlannerCost`.
                 When ``None``, uses this planner's step-normalized distance.
+            publisher: Optional telemetry sink.  Defaults to file IPC via
+                :func:`~arco.planning.continuous.telemetry.write_telemetry`.
+            seed: Optional RNG seed when *rng* is omitted.
+            rng: Optional NumPy generator (overrides *seed*).
 
         Raises:
             ValueError: If *bounds* is empty or any element of *step_size*
                 is not positive.
         """
-        super().__init__(occupancy, cost=cost)
+        super().__init__(
+            occupancy,
+            cost=cost,
+            publisher=publisher,
+            seed=seed,
+            rng=rng,
+        )
         if not bounds:
             raise ValueError("bounds must not be empty.")
         self.step_size = np.asarray(step_size, dtype=float)
@@ -222,12 +234,12 @@ class SSTPlanner(ContinuousPlanner):
         best_goal_node: Optional[int] = None
         best_goal_cost = math.inf
         _best_dist_to_goal = math.inf
-        rng = np.random.default_rng()
+        rng = self.make_rng()
 
         for iteration in range(self.max_sample_count):
             # --- Telemetry -----------------------------------------------
             if iteration % TELEMETRY_WRITE_INTERVAL == 0:
-                write_telemetry(
+                self.publish_telemetry(
                     PlannerTelemetry(
                         algorithm="SST",
                         step_name="exploring",

--- a/src/arco/planning/continuous/sst.py
+++ b/src/arco/planning/continuous/sst.py
@@ -257,9 +257,7 @@ class SSTPlanner(ContinuousPlanner):
             if not self._segment_free(x_selected, x_new):
                 continue
 
-            new_cost = cost[x_selected_idx] + float(
-                np.linalg.norm((x_new - x_selected) / self.step_size)
-            )
+            new_cost = cost[x_selected_idx] + self.distance(x_selected, x_new)
 
             # --- Witness update ------------------------------------------
             w_idx = self._nearest_witness(witnesses, x_new)
@@ -289,9 +287,7 @@ class SSTPlanner(ContinuousPlanner):
             witness_rep[w_idx] = new_idx
 
             # --- Goal check ----------------------------------------------
-            dist_to_goal = float(
-                np.linalg.norm((x_new - goal) / self.step_size)
-            )
+            dist_to_goal = self.distance(x_new, goal)
             if dist_to_goal < _best_dist_to_goal:
                 _best_dist_to_goal = dist_to_goal
             if (
@@ -401,9 +397,7 @@ class SSTPlanner(ContinuousPlanner):
             return None
         return min(
             active,
-            key=lambda i: float(
-                np.linalg.norm((nodes[i] - x_rand) / self.step_size)
-            ),
+            key=lambda i: self.distance(nodes[i], x_rand),
         )
 
     def _steer(self, from_pt: np.ndarray, to_pt: np.ndarray) -> np.ndarray:
@@ -418,7 +412,7 @@ class SSTPlanner(ContinuousPlanner):
             in normalized space.
         """
         delta = to_pt - from_pt
-        dist = float(np.linalg.norm(delta / self.step_size))
+        dist = self.distance(from_pt, to_pt)
         if dist <= 1.0:
             return to_pt.copy()
         return from_pt + delta / dist
@@ -441,7 +435,7 @@ class SSTPlanner(ContinuousPlanner):
         best_idx: Optional[int] = None
         best_dist = math.inf
         for i, w in enumerate(witnesses):
-            d = float(np.linalg.norm((w - point) / self.step_size))
+            d = self.distance(w, point)
             if d < best_dist and d <= self.witness_radius:
                 best_dist = d
                 best_idx = i

--- a/src/arco/planning/continuous/sst.py
+++ b/src/arco/planning/continuous/sst.py
@@ -517,6 +517,9 @@ class SSTPlanner(ContinuousPlanner):
     def _segment_free(self, a: np.ndarray, b: np.ndarray) -> bool:
         """Check whether the segment from *a* to *b* is collision-free.
 
+        Delegates to :meth:`~arco.mapping.occupancy.Occupancy.segment_free`
+        with ``collision_check_count + 2`` samples.
+
         Args:
             a: Segment start.
             b: Segment end.
@@ -524,11 +527,9 @@ class SSTPlanner(ContinuousPlanner):
         Returns:
             True if no intermediate point is occupied.
         """
-        for t in np.linspace(0.0, 1.0, self.collision_check_count + 2):
-            pt = a + t * (b - a)
-            if self.occupancy.is_occupied(pt):
-                return False
-        return True
+        return self.occupancy.segment_free(
+            a, b, sample_count=self.collision_check_count + 2
+        )
 
     def _extract_path(
         self,

--- a/src/arco/planning/continuous/telemetry.py
+++ b/src/arco/planning/continuous/telemetry.py
@@ -111,6 +111,15 @@ def write_telemetry(
         pass
 
 
+def noop_publisher(telemetry: PlannerTelemetry) -> None:
+    """Discard a telemetry snapshot (disable file IPC).
+
+    Args:
+        telemetry: Ignored snapshot.
+    """
+    return None
+
+
 def read_telemetry(
     path: Path = DEFAULT_TELEMETRY_PATH,
 ) -> Optional[PlannerTelemetry]:

--- a/src/arco/planning/cost.py
+++ b/src/arco/planning/cost.py
@@ -1,0 +1,47 @@
+"""Shared default cost primitives for path planners."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+class PlannerCost:
+    """Default distance and heuristic cost functions for planners.
+
+    A*, RRT*, and SST inherit these methods through their discrete or
+    continuous base classes.  Override :meth:`distance` and/or
+    :meth:`heuristic` in a subclass to customize edge cost and the
+    remaining-cost estimate without rewriting the search algorithm.
+
+    Default metric: Euclidean distance between array-like states.
+    The default heuristic equals :meth:`distance` and is therefore
+    admissible for Euclidean path costs.
+    """
+
+    def distance(self, state_a: Any, state_b: Any) -> float:
+        """Return the transition cost between two states.
+
+        Args:
+            state_a: Origin state (array-like).
+            state_b: Destination state (array-like).
+
+        Returns:
+            Non-negative Euclidean distance between the states.
+        """
+        a = np.asarray(state_a, dtype=float).reshape(-1)
+        b = np.asarray(state_b, dtype=float).reshape(-1)
+        return float(np.linalg.norm(b - a))
+
+    def heuristic(self, state_a: Any, state_b: Any) -> float:
+        """Return an admissible estimate of remaining cost from a to b.
+
+        Args:
+            state_a: Current state (array-like).
+            state_b: Goal state (array-like).
+
+        Returns:
+            Estimated remaining cost.  Defaults to :meth:`distance`.
+        """
+        return self.distance(state_a, state_b)

--- a/src/arco/planning/discrete/__init__.py
+++ b/src/arco/planning/discrete/__init__.py
@@ -1,5 +1,17 @@
+"""Discrete planners operating on graphs and grids."""
+
 from .api import AStar, DStarLite
 from .astar import AStarPlanner
 from .base import DiscretePlanner
 from .dstar import DStarPlanner
 from .route import RouteResult, RouteRouter
+
+__all__ = [
+    "AStar",
+    "AStarPlanner",
+    "DStarLite",
+    "DStarPlanner",
+    "DiscretePlanner",
+    "RouteResult",
+    "RouteRouter",
+]

--- a/src/arco/planning/discrete/astar.py
+++ b/src/arco/planning/discrete/astar.py
@@ -41,6 +41,8 @@ class AStarPlanner(DiscretePlanner):
         self,
         graph: Any,
         heuristic: Optional[Callable[[Any, Any], float]] = None,
+        simplify_path: bool = True,
+        prefer_straight: bool = True,
     ) -> None:
         """Initialize AStarPlanner.
 
@@ -52,9 +54,15 @@ class AStarPlanner(DiscretePlanner):
                 When set, it overrides :meth:`heuristic`.  Otherwise the
                 discrete base uses ``graph.heuristic`` if available, else
                 ``graph.distance``.
+            simplify_path: When ``True`` (default), collapse collinear runs
+                after a successful search.
+            prefer_straight: When ``True`` (default), use direction-continuity
+                as a tie-break key in the open set (does not change ``g``).
         """
         super().__init__(graph)
         self._heuristic_override = heuristic
+        self.simplify_path = simplify_path
+        self.prefer_straight = prefer_straight
         if heuristic is not None:
             logger.debug("Setting custom heuristic override")
         elif hasattr(graph, "heuristic"):
@@ -142,7 +150,10 @@ class AStarPlanner(DiscretePlanner):
             expanded_count += 1
             if current == goal:
                 path = self._reconstruct_path(came_from, current)
-                simplified_path = self._simplify_path(path)
+                if self.simplify_path:
+                    simplified_path = self._simplify_path(path)
+                else:
+                    simplified_path = path
                 logger.debug(
                     (
                         "A*: finished success raw_length=%d simplified_length=%d "
@@ -163,10 +174,10 @@ class AStarPlanner(DiscretePlanner):
                 tentative_g = g_score[current] + self.distance(
                     current, neighbor
                 )
-                direction_change_penalty = self._turn_penalty(
-                    current,
-                    neighbor,
-                    came_from,
+                direction_change_penalty = (
+                    self._turn_penalty(current, neighbor, came_from)
+                    if self.prefer_straight
+                    else 0
                 )
                 better_cost = (
                     neighbor not in g_score

--- a/src/arco/planning/discrete/astar.py
+++ b/src/arco/planning/discrete/astar.py
@@ -26,14 +26,16 @@ class AStarPlanner(DiscretePlanner):
     insertion counter (FIFO among equal h). This avoids lexicographic
     comparison of node tuples and reduces zig-zagging in symmetric grids.
 
-    Default heuristic: ``graph.heuristic`` if the graph exposes it,
-    otherwise ``graph.distance``.  Grid subclasses expose a Euclidean
-    ``heuristic`` which is admissible on both Manhattan and Euclidean
-    grids and guides A* toward diagonal/staircase paths instead of the
-    L-shape that arises when all f-scores are tied.
-    """
+    Cost functions come from :class:`~arco.planning.cost.PlannerCost` via
+    :class:`~arco.planning.discrete.base.DiscretePlanner`:
 
-    heuristic: Callable[[Any, Any], float]
+    - :meth:`distance` delegates to ``graph.distance`` (edge cost ``g``).
+    - :meth:`heuristic` uses an optional constructor override, else
+      ``graph.heuristic`` when available, else :meth:`distance`.
+
+    Override those methods in a subclass to customize costs without
+    rewriting the search loop.
+    """
 
     def __init__(
         self,
@@ -47,19 +49,34 @@ class AStarPlanner(DiscretePlanner):
                 and ``distance`` methods. Optionally exposes ``heuristic``
                 and ``is_occupied``.
             heuristic: Optional heuristic callable ``(node, goal) -> float``.
-                Defaults to ``graph.heuristic`` if available, else
+                When set, it overrides :meth:`heuristic`.  Otherwise the
+                discrete base uses ``graph.heuristic`` if available, else
                 ``graph.distance``.
         """
         super().__init__(graph)
+        self._heuristic_override = heuristic
         if heuristic is not None:
-            self.heuristic = heuristic
-            logger.debug("Setting custom heuristic")
+            logger.debug("Setting custom heuristic override")
         elif hasattr(graph, "heuristic"):
-            self.heuristic = graph.heuristic
             logger.debug("Using graph-provided heuristic")
         else:
-            self.heuristic = graph.distance
             logger.debug("Using graph distance as heuristic")
+
+    def heuristic(self, state_a: Any, state_b: Any) -> float:
+        """Return the remaining-cost estimate from *state_a* to *state_b*.
+
+        Args:
+            state_a: Current node.
+            state_b: Goal node.
+
+        Returns:
+            Heuristic cost.  Uses the constructor override when provided;
+            otherwise delegates to
+            :meth:`DiscretePlanner.heuristic`.
+        """
+        if self._heuristic_override is not None:
+            return float(self._heuristic_override(state_a, state_b))
+        return super().heuristic(state_a, state_b)
 
     def plan(self, start: Any, goal: Any) -> Optional[List[Any]]:
         """Plan a path from start to goal using A*.
@@ -143,7 +160,7 @@ class AStarPlanner(DiscretePlanner):
                     self.graph, "is_occupied"
                 ) and self.graph.is_occupied(neighbor):
                     continue
-                tentative_g = g_score[current] + self.graph.distance(
+                tentative_g = g_score[current] + self.distance(
                     current, neighbor
                 )
                 direction_change_penalty = self._turn_penalty(

--- a/src/arco/planning/discrete/base.py
+++ b/src/arco/planning/discrete/base.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 from typing import Any
 
+from arco.planning.cost import PlannerCost
 
-class DiscretePlanner:
+
+class DiscretePlanner(PlannerCost):
     """
     Base class for discrete planners operating on graphs (including grids).
 
     Accepts any Graph (e.g., Grid, Occupancy, custom Graph).
+    Inherits default :meth:`distance` / :meth:`heuristic` from
+    :class:`~arco.planning.cost.PlannerCost`, and overrides them to
+    delegate to the attached graph.
     """
 
     graph: Any
@@ -20,5 +25,35 @@ class DiscretePlanner:
 
         Args:
             graph: The graph structure (Grid, Occupancy, or custom Graph).
+                Must expose ``distance``.  Optionally exposes ``heuristic``.
         """
         self.graph = graph
+
+    def distance(self, state_a: Any, state_b: Any) -> float:
+        """Return the graph edge cost between two nodes.
+
+        Args:
+            state_a: Origin node.
+            state_b: Destination node.
+
+        Returns:
+            Edge cost from ``graph.distance``.
+        """
+        return float(self.graph.distance(state_a, state_b))
+
+    def heuristic(self, state_a: Any, state_b: Any) -> float:
+        """Return a remaining-cost estimate between two nodes.
+
+        Uses ``graph.heuristic`` when available; otherwise falls back to
+        :meth:`distance`.
+
+        Args:
+            state_a: Current node.
+            state_b: Goal node.
+
+        Returns:
+            Heuristic cost estimate.
+        """
+        if hasattr(self.graph, "heuristic"):
+            return float(self.graph.heuristic(state_a, state_b))
+        return self.distance(state_a, state_b)

--- a/src/arco/planning/discrete/route.py
+++ b/src/arco/planning/discrete/route.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import List, NamedTuple, Optional
+from typing import Any, List, NamedTuple, Optional
 
 import numpy as np
 
@@ -63,6 +63,7 @@ class RouteRouter:
         self,
         graph: CartesianGraph,
         activation_radius: Optional[float] = None,
+        planner: Optional[Any] = None,
     ) -> None:
         """Initialize RouteRouter.
 
@@ -72,10 +73,14 @@ class RouteRouter:
                 positions onto graph nodes.  If ``None``, any distance is
                 accepted.  Recommended to set this to prevent routing from
                 positions far from valid roads.
+            planner: Optional discrete planner exposing
+                ``plan(start_node, goal_node)``.  Defaults to
+                :class:`~arco.planning.discrete.astar.AStarPlanner` on
+                *graph*.
         """
         self.graph = graph
         self.activation_radius = activation_radius
-        self._planner = AStarPlanner(graph)
+        self._planner = planner if planner is not None else AStarPlanner(graph)
 
     def plan(
         self,

--- a/src/arco/protocols/__init__.py
+++ b/src/arco/protocols/__init__.py
@@ -1,0 +1,36 @@
+"""Structural protocols for ARCO extension points.
+
+These typing protocols document duck-typed contracts already used across
+mapping, planning, guidance, and control.  They impose no runtime
+behavior change; existing classes satisfy them structurally.
+"""
+
+from .avoidance import AvoidanceStrategy
+from .cost_term import CostTerm
+from .discrete_map import DiscreteMap
+from .occupancy import OccupancyLike
+from .optimizer import OptimizerLike
+from .path_tracker import PathTracker
+from .planner import PlannerLike
+from .pruner import PrunerLike
+from .sampler import Sampler
+from .segment_checker import SegmentChecker
+from .steerer import Steerer
+from .telemetry import TelemetryPublisher
+from .vehicle import VehicleModel
+
+__all__ = [
+    "AvoidanceStrategy",
+    "CostTerm",
+    "DiscreteMap",
+    "OccupancyLike",
+    "OptimizerLike",
+    "PathTracker",
+    "PlannerLike",
+    "PrunerLike",
+    "Sampler",
+    "SegmentChecker",
+    "Steerer",
+    "TelemetryPublisher",
+    "VehicleModel",
+]

--- a/src/arco/protocols/avoidance.py
+++ b/src/arco/protocols/avoidance.py
@@ -1,0 +1,18 @@
+"""AvoidanceStrategy: duck-typed contract for reactive obstacle avoidance."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class AvoidanceStrategy(Protocol):
+    """Reactive avoidance correction used by path-tracking loops.
+
+    ``__call__(x, y, theta) → turn_rate_bias`` returns an additive turn-rate
+    correction (rad/s).  The default APF strategy returns ``0.0`` when
+    disabled or when no obstacle is nearby.
+    """
+
+    def __call__(self, x: float, y: float, theta: float) -> float:
+        """Return an additive turn-rate bias for pose ``(x, y, theta)``."""

--- a/src/arco/protocols/cost_term.py
+++ b/src/arco/protocols/cost_term.py
@@ -1,0 +1,22 @@
+"""CostTerm: duck-typed contract for optimizer cost contributions."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Protocol, runtime_checkable
+
+import numpy as np
+
+
+@runtime_checkable
+class CostTerm(Protocol):
+    """One term of a composite trajectory cost.
+
+    ``__call__(context) → float`` receives a dict with unpacked
+    durations, waypoints, and optimizer settings (see
+    :class:`~arco.planning.continuous.optimizer.TrajectoryOptimizer`).
+    """
+
+    name: str
+
+    def __call__(self, context: Dict[str, Any]) -> float:
+        """Evaluate this term given the optimization context."""

--- a/src/arco/protocols/discrete_map.py
+++ b/src/arco/protocols/discrete_map.py
@@ -1,0 +1,21 @@
+"""DiscreteMap: duck-typed contract for discrete planners."""
+
+from __future__ import annotations
+
+from typing import Any, Iterator, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class DiscreteMap(Protocol):
+    """Map/graph surface expected by discrete planners (A*, route).
+
+    Concrete types include grids and weighted/Cartesian graphs.  Optional
+    members ``heuristic`` and ``is_occupied`` are detected via
+    ``hasattr`` by planners when present.
+    """
+
+    def neighbors(self, node: Any) -> Iterator[Any]:
+        """Yield adjacent nodes of *node*."""
+
+    def distance(self, node_a: Any, node_b: Any) -> float:
+        """Return the edge cost between two adjacent nodes."""

--- a/src/arco/protocols/occupancy.py
+++ b/src/arco/protocols/occupancy.py
@@ -1,0 +1,23 @@
+"""OccupancyLike: duck-typed contract for continuous collision maps."""
+
+from __future__ import annotations
+
+from typing import Protocol, Tuple, runtime_checkable
+
+import numpy as np
+
+
+@runtime_checkable
+class OccupancyLike(Protocol):
+    """Continuous occupancy surface used by RRT*/SST/pruner/optimizer.
+
+    Required methods match :class:`~arco.mapping.occupancy.Occupancy`.
+    Optional attributes ``clearance`` and ``query_distances`` are used by
+    pruner/optimizer when available.
+    """
+
+    def nearest_obstacle(self, point: np.ndarray) -> Tuple[float, np.ndarray]:
+        """Return ``(distance, nearest_point)`` for the closest obstacle."""
+
+    def is_occupied(self, point: np.ndarray) -> bool:
+        """Return True if *point* is in collision."""

--- a/src/arco/protocols/optimizer.py
+++ b/src/arco/protocols/optimizer.py
@@ -1,0 +1,15 @@
+"""OptimizerLike: duck-typed contract for pipeline optimizers."""
+
+from __future__ import annotations
+
+from typing import Any, List, Protocol, runtime_checkable
+
+import numpy as np
+
+
+@runtime_checkable
+class OptimizerLike(Protocol):
+    """Optimizer stage: ``optimize(path) → result``."""
+
+    def optimize(self, path: List[np.ndarray]) -> Any:
+        """Refine *path* into a time-parameterized trajectory result."""

--- a/src/arco/protocols/path_tracker.py
+++ b/src/arco/protocols/path_tracker.py
@@ -1,0 +1,26 @@
+"""PathTracker: duck-typed contract for geometric path trackers."""
+
+from __future__ import annotations
+
+from typing import Protocol, Sequence, runtime_checkable
+
+
+@runtime_checkable
+class PathTracker(Protocol):
+    """Geometric path tracker used by :class:`~arco.control.tracking.TrackingLoop`.
+
+    Matches :class:`~arco.control.pure_pursuit.PurePursuitController.track`
+    plus the error/curvature attributes the loop reads after each call.
+    """
+
+    cross_track_error: float
+    heading_error: float
+    curvature: float
+
+    def track(
+        self,
+        pose: tuple[float, float, float],
+        path: Sequence[tuple[float, float]],
+        speed: float = 1.0,
+    ) -> tuple[float, float]:
+        """Return ``(speed_cmd, turn_rate_cmd)`` for the current pose."""

--- a/src/arco/protocols/planner.py
+++ b/src/arco/protocols/planner.py
@@ -1,0 +1,17 @@
+"""PlannerLike: duck-typed contract for pipeline planners."""
+
+from __future__ import annotations
+
+from typing import List, Optional, Protocol, runtime_checkable
+
+import numpy as np
+
+
+@runtime_checkable
+class PlannerLike(Protocol):
+    """Continuous planner stage: ``plan(start, goal) → path | None``."""
+
+    def plan(
+        self, start: np.ndarray, goal: np.ndarray
+    ) -> Optional[List[np.ndarray]]:
+        """Plan a path from *start* to *goal*."""

--- a/src/arco/protocols/pruner.py
+++ b/src/arco/protocols/pruner.py
@@ -1,0 +1,15 @@
+"""PrunerLike: duck-typed contract for pipeline pruners."""
+
+from __future__ import annotations
+
+from typing import List, Protocol, runtime_checkable
+
+import numpy as np
+
+
+@runtime_checkable
+class PrunerLike(Protocol):
+    """Pruner stage: ``prune(path) → shortened path``."""
+
+    def prune(self, path: List[np.ndarray]) -> List[np.ndarray]:
+        """Return a shortened collision-free path."""

--- a/src/arco/protocols/sampler.py
+++ b/src/arco/protocols/sampler.py
@@ -1,0 +1,18 @@
+"""Sampler: duck-typed contract for continuous planner sampling."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+
+@runtime_checkable
+class Sampler(Protocol):
+    """Random-state sampler used by RRT*/SST.
+
+    ``__call__(rng) → state`` matches the default uniform AABB sampler.
+    """
+
+    def __call__(self, rng: np.random.Generator) -> np.ndarray:
+        """Return a random state sample."""

--- a/src/arco/protocols/segment_checker.py
+++ b/src/arco/protocols/segment_checker.py
@@ -1,0 +1,18 @@
+"""SegmentChecker: duck-typed contract for edge collision checks."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+
+@runtime_checkable
+class SegmentChecker(Protocol):
+    """Collision checker for a straight segment between two states.
+
+    ``__call__(a, b) → bool`` returns True when the segment is free.
+    """
+
+    def __call__(self, a: np.ndarray, b: np.ndarray) -> bool:
+        """Return True if the segment from *a* to *b* is collision-free."""

--- a/src/arco/protocols/steerer.py
+++ b/src/arco/protocols/steerer.py
@@ -1,0 +1,19 @@
+"""Steerer: duck-typed contract for continuous planner extension."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+
+@runtime_checkable
+class Steerer(Protocol):
+    """Steering law used by RRT*/SST (and optional pruner feasibility).
+
+    ``__call__(from_pt, to_pt) → new_state`` matches the default
+    step-size-limited straight-line steerer.
+    """
+
+    def __call__(self, from_pt: np.ndarray, to_pt: np.ndarray) -> np.ndarray:
+        """Steer from *from_pt* toward *to_pt* by at most one step."""

--- a/src/arco/protocols/telemetry.py
+++ b/src/arco/protocols/telemetry.py
@@ -1,0 +1,20 @@
+"""TelemetryPublisher: duck-typed contract for planner telemetry sinks."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class TelemetryPublisher(Protocol):
+    """Sink for planner telemetry snapshots.
+
+    The default implementation writes JSON to a temp file.  Inject a
+    no-op or custom publisher to disable or redirect telemetry.
+
+    Args accepted by ``__call__`` match
+    :class:`~arco.planning.continuous.telemetry.PlannerTelemetry`.
+    """
+
+    def __call__(self, telemetry: Any) -> None:
+        """Publish one telemetry snapshot."""

--- a/src/arco/protocols/vehicle.py
+++ b/src/arco/protocols/vehicle.py
@@ -1,0 +1,28 @@
+"""VehicleModel: duck-typed contract for SE(2) kinematic vehicles."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class VehicleModel(Protocol):
+    """SE(2) vehicle surface used by tracking loops.
+
+    Matches :class:`~arco.guidance.vehicle.DubinsVehicle` pose/step API.
+    """
+
+    @property
+    def pose(self) -> tuple[float, float, float]:
+        """Current pose as ``(x, y, heading)``."""
+
+    @property
+    def speed(self) -> float:
+        """Current forward speed (m/s)."""
+
+    @property
+    def turn_rate(self) -> float:
+        """Current turn rate (rad/s)."""
+
+    def step(self, speed_cmd: float, turn_rate_cmd: float, dt: float) -> None:
+        """Integrate one control step of duration *dt*."""

--- a/tests/control/mpc/test_costs.py
+++ b/tests/control/mpc/test_costs.py
@@ -1,0 +1,126 @@
+"""Unit tests for shared MPC soft-barrier cost helpers."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from arco.control.mpc.costs import forward_cone_factor, obstacle_barrier
+
+
+def _ref_obstacle_barrier(
+    distance: float,
+    clearance: float,
+    weight: float,
+    power: float,
+    cone_factor: float,
+) -> float:
+    """Float reference matching the former inlined MPC barrier."""
+    denom = max(clearance, 1e-6)
+    penetration = max(0.0, (clearance - distance) / denom)
+    directional = 0.2 + 0.8 * cone_factor
+    return weight * (penetration**power) * directional
+
+
+def _ref_forward_cone(
+    pose_x: float,
+    pose_y: float,
+    heading: float,
+    obstacle_x: float,
+    obstacle_y: float,
+) -> float:
+    """Float reference: heading projection (path-following formula)."""
+    dx = obstacle_x - pose_x
+    dy = obstacle_y - pose_y
+    dist = math.sqrt(dx * dx + dy * dy + 1e-9)
+    fwd = (math.cos(heading) * dx + math.sin(heading) * dy) / dist
+    return max(0.0, fwd)
+
+
+@pytest.mark.parametrize(
+    "distance,clearance,weight,power,cone_factor",
+    [
+        (0.5, 1.0, 10.0, 4.0, 1.0),
+        (0.2, 1.0, 10.0, 4.0, 0.0),
+        (0.0, 0.5, 5.0, 2.0, 0.5),
+        (2.0, 1.0, 10.0, 4.0, 1.0),  # outside clearance → 0
+        (0.8, 1.0, 1.0, 4.0, 1.0),  # joint-space: cone_factor=1
+    ],
+)
+def test_obstacle_barrier_matches_float_reference(
+    distance: float,
+    clearance: float,
+    weight: float,
+    power: float,
+    cone_factor: float,
+) -> None:
+    expected = _ref_obstacle_barrier(
+        distance, clearance, weight, power, cone_factor
+    )
+    got = obstacle_barrier(distance, clearance, weight, power, cone_factor)
+    assert got == pytest.approx(expected, rel=0.0, abs=1e-12)
+
+
+@pytest.mark.parametrize(
+    "pose_x,pose_y,heading,ox,oy",
+    [
+        (0.0, 0.0, 0.0, 1.0, 0.0),  # straight ahead → 1
+        (0.0, 0.0, 0.0, -1.0, 0.0),  # behind → 0
+        (0.0, 0.0, 0.0, 0.0, 1.0),  # 90° → 0
+        (1.0, 2.0, math.pi / 4, 2.0, 3.0),
+    ],
+)
+def test_forward_cone_factor_matches_float_reference(
+    pose_x: float,
+    pose_y: float,
+    heading: float,
+    ox: float,
+    oy: float,
+) -> None:
+    expected = _ref_forward_cone(pose_x, pose_y, heading, ox, oy)
+    got = forward_cone_factor(pose_x, pose_y, heading, ox, oy)
+    assert got == pytest.approx(expected, rel=0.0, abs=1e-12)
+    # Also matches cos(heading − bearing) away from the origin.
+    bearing = math.atan2(oy - pose_y, ox - pose_x)
+    atan2_ref = max(0.0, math.cos(heading - bearing))
+    assert got == pytest.approx(atan2_ref, abs=1e-9)
+
+
+def test_joint_space_cone_factor_one_is_identity_directional() -> None:
+    """cone_factor=1.0 → directional weight is exactly 1 (joint-space)."""
+    distance, clearance, weight, power = 0.25, 1.0, 8.0, 4.0
+    got = obstacle_barrier(distance, clearance, weight, power, 1.0)
+    denom = max(clearance, 1e-6)
+    penetration = max(0.0, (clearance - distance) / denom)
+    assert got == pytest.approx(weight * (penetration**power))
+
+
+def test_casadi_obstacle_barrier_matches_float() -> None:
+    ca = pytest.importorskip("casadi")
+    distance, clearance = 0.4, 1.0
+    weight, power, cone = 10.0, 4.0, 0.75
+    expected = _ref_obstacle_barrier(distance, clearance, weight, power, cone)
+    d = ca.MX.sym("d")
+    c = ca.MX.sym("c")
+    cf = ca.MX.sym("cf")
+    expr = obstacle_barrier(d, c, weight, power, cf)
+    fn = ca.Function("b", [d, c, cf], [expr])
+    got = float(fn(distance, clearance, cone))
+    assert got == pytest.approx(expected, abs=1e-12)
+
+
+def test_casadi_forward_cone_matches_float() -> None:
+    ca = pytest.importorskip("casadi")
+    pose_x, pose_y, heading = 0.0, 0.0, 0.3
+    ox, oy = 1.5, 0.4
+    expected = _ref_forward_cone(pose_x, pose_y, heading, ox, oy)
+    px = ca.MX.sym("px")
+    py = ca.MX.sym("py")
+    th = ca.MX.sym("th")
+    ox_s = ca.MX.sym("ox")
+    oy_s = ca.MX.sym("oy")
+    expr = forward_cone_factor(px, py, th, ox_s, oy_s)
+    fn = ca.Function("cone", [px, py, th, ox_s, oy_s], [expr])
+    got = float(fn(pose_x, pose_y, heading, ox, oy))
+    assert got == pytest.approx(expected, abs=1e-12)

--- a/tests/control/test_avoidance.py
+++ b/tests/control/test_avoidance.py
@@ -1,0 +1,250 @@
+"""Tests for ArtificialPotentialField and TrackingLoop avoidance injection."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from arco.control import ArtificialPotentialField, TrackingLoop
+from arco.control.avoidance import ArtificialPotentialField as APFDirect
+from arco.control.pure_pursuit import PurePursuitController
+from arco.guidance.vehicle import DubinsVehicle
+from arco.protocols.avoidance import AvoidanceStrategy
+
+STRAIGHT_PATH: list[tuple[float, float]] = [(float(i), 0.0) for i in range(40)]
+
+
+class _NearObstacleOccupancy:
+    """Minimal occupancy stub: single obstacle at a fixed position."""
+
+    def __init__(
+        self,
+        obs_x: float,
+        obs_y: float,
+        clearance: float,
+    ) -> None:
+        self.clearance = clearance
+        self._obs = (obs_x, obs_y)
+
+    def nearest_obstacle(
+        self, point: np.ndarray
+    ) -> tuple[float, np.ndarray]:
+        obs = np.array(self._obs, dtype=float)
+        dist = float(np.linalg.norm(np.asarray(point, dtype=float) - obs))
+        return dist, obs
+
+
+def _make_vehicle() -> DubinsVehicle:
+    """Create a DubinsVehicle with relaxed actuator limits for unit tests."""
+    return DubinsVehicle(
+        x=0.0,
+        y=0.0,
+        heading=0.0,
+        max_speed=5.0,
+        min_speed=0.0,
+        max_turn_rate=4.0,
+        max_acceleration=10.0,
+        max_turn_rate_dot=10.0,
+    )
+
+
+def _make_apf(
+    obs_x: float,
+    obs_y: float,
+    clearance: float = 2.0,
+    repulsion_gain: float = 1.5,
+) -> ArtificialPotentialField:
+    """Build an APF aimed at a single fixed obstacle."""
+    occ = _NearObstacleOccupancy(obs_x, obs_y, clearance)
+    return ArtificialPotentialField(
+        occupancy=occ, repulsion_gain=repulsion_gain
+    )
+
+
+# ---------------------------------------------------------------------------
+# ArtificialPotentialField unit behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_apf_exported_from_control_package() -> None:
+    """ArtificialPotentialField is re-exported from arco.control."""
+    assert ArtificialPotentialField is APFDirect
+
+
+def test_apf_satisfies_avoidance_strategy_protocol() -> None:
+    """APF instances are runtime-checkable AvoidanceStrategy objects."""
+    apf = ArtificialPotentialField()
+    assert isinstance(apf, AvoidanceStrategy)
+
+
+def test_apf_noop_when_occupancy_none() -> None:
+    """Disabled path: no occupancy → always zero correction."""
+    apf = ArtificialPotentialField(occupancy=None, repulsion_gain=2.0)
+    assert apf(0.0, 0.0, 0.0) == 0.0
+
+
+def test_apf_noop_when_gain_nonpositive() -> None:
+    """Disabled path: non-positive gain → always zero correction."""
+    occ = _NearObstacleOccupancy(0.5, 0.0, clearance=2.0)
+    apf = ArtificialPotentialField(occupancy=occ, repulsion_gain=0.0)
+    assert apf(0.0, 0.0, 0.0) == 0.0
+    apf_neg = ArtificialPotentialField(occupancy=occ, repulsion_gain=-1.0)
+    assert apf_neg(0.0, 0.0, 0.0) == 0.0
+
+
+def test_apf_zero_outside_influence_radius() -> None:
+    """No repulsion when obstacle is beyond 2 × clearance."""
+    apf = _make_apf(obs_x=100.0, obs_y=0.0, clearance=2.0)
+    assert apf(0.0, 0.0, 0.0) == 0.0
+
+
+def test_apf_nonzero_inside_influence_radius() -> None:
+    """Repulsion is non-zero when obstacle is within 2 × clearance."""
+    apf = _make_apf(obs_x=1.5, obs_y=0.0, clearance=2.0)
+    assert apf(0.0, 0.0, 0.0) != 0.0
+
+
+def test_apf_direction_obstacle_left() -> None:
+    """Obstacle to the left → negative turn rate (steer right)."""
+    apf = _make_apf(obs_x=1.0, obs_y=1.0, clearance=4.0)
+    assert apf(0.0, 0.0, 0.0) < 0.0
+
+
+def test_apf_direction_obstacle_right() -> None:
+    """Obstacle to the right → positive turn rate (steer left)."""
+    apf = _make_apf(obs_x=1.0, obs_y=-1.0, clearance=4.0)
+    assert apf(0.0, 0.0, 0.0) > 0.0
+
+
+def test_apf_magnitude_scales_with_gain() -> None:
+    """Doubling repulsion_gain doubles the correction magnitude."""
+    occ = _NearObstacleOccupancy(1.0, 1.0, clearance=4.0)
+    r1 = ArtificialPotentialField(occ, repulsion_gain=1.0)(0.0, 0.0, 0.0)
+    r2 = ArtificialPotentialField(occ, repulsion_gain=2.0)(0.0, 0.0, 0.0)
+    assert abs(r2) == abs(2.0 * r1)
+
+
+# ---------------------------------------------------------------------------
+# TrackingLoop default APF (backwards-compatible kwargs)
+# ---------------------------------------------------------------------------
+
+
+def test_tracking_loop_default_apf_from_occupancy_kwargs() -> None:
+    """When avoidance is omitted, occupancy + gain build a default APF."""
+    occ = _NearObstacleOccupancy(1.0, 1.0, clearance=4.0)
+    loop = TrackingLoop(
+        _make_vehicle(),
+        PurePursuitController(lookahead_distance=2.0),
+        cruise_speed=1.0,
+        occupancy=occ,
+        repulsion_gain=1.5,
+    )
+    assert loop._avoidance is not None
+    assert isinstance(loop._avoidance, ArtificialPotentialField)
+    r = loop._repulsion_turn_rate(0.0, 0.0, 0.0)
+    assert r < 0.0
+
+
+def test_tracking_loop_no_default_apf_when_gain_zero() -> None:
+    """repulsion_gain=0 leaves avoidance disabled even with occupancy."""
+    occ = _NearObstacleOccupancy(0.5, 0.0, clearance=2.0)
+    loop = TrackingLoop(
+        _make_vehicle(),
+        PurePursuitController(lookahead_distance=2.0),
+        cruise_speed=1.0,
+        occupancy=occ,
+        repulsion_gain=0.0,
+    )
+    assert loop._avoidance is None
+    assert loop._repulsion_turn_rate(0.0, 0.0, 0.0) == 0.0
+
+
+def test_tracking_loop_no_default_apf_without_occupancy() -> None:
+    """No occupancy → no default avoidance, even with positive gain."""
+    loop = TrackingLoop(
+        _make_vehicle(),
+        PurePursuitController(lookahead_distance=2.0),
+        cruise_speed=1.0,
+        repulsion_gain=2.0,
+    )
+    assert loop._avoidance is None
+    assert loop._repulsion_turn_rate(0.0, 0.0, 0.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# TrackingLoop injectable avoidance
+# ---------------------------------------------------------------------------
+
+
+class _ConstantAvoidance:
+    """Stub AvoidanceStrategy returning a fixed turn-rate bias."""
+
+    def __init__(self, bias: float) -> None:
+        self.bias = bias
+        self.call_count = 0
+
+    def __call__(self, x: float, y: float, theta: float) -> float:
+        self.call_count += 1
+        return self.bias
+
+
+def test_tracking_loop_uses_injected_avoidance() -> None:
+    """Explicit avoidance replaces the default APF entirely."""
+    stub = _ConstantAvoidance(bias=0.42)
+    occ = _NearObstacleOccupancy(0.5, 0.0, clearance=2.0)
+    loop = TrackingLoop(
+        _make_vehicle(),
+        PurePursuitController(lookahead_distance=2.0),
+        cruise_speed=1.0,
+        occupancy=occ,
+        repulsion_gain=9.0,
+        avoidance=stub,
+    )
+    assert loop._avoidance is stub
+    assert loop._repulsion_turn_rate(0.0, 0.0, 0.0) == 0.42
+
+
+def test_tracking_loop_step_applies_injected_avoidance() -> None:
+    """step() blends the injected avoidance bias into turn_rate metrics."""
+    stub = _ConstantAvoidance(bias=0.25)
+    loop = TrackingLoop(
+        _make_vehicle(),
+        PurePursuitController(lookahead_distance=2.0),
+        cruise_speed=1.0,
+        avoidance=stub,
+    )
+    metrics = loop.step(STRAIGHT_PATH, dt=0.1)
+    assert metrics["repulsion_turn_rate"] == 0.25
+    assert stub.call_count == 1
+
+
+def test_tracking_loop_noop_apf_disables_despite_occupancy_kwargs() -> None:
+    """Injected no-op APF disables repulsion even when kwargs would enable it."""
+    noop = ArtificialPotentialField(occupancy=None, repulsion_gain=0.0)
+    loop = TrackingLoop(
+        _make_vehicle(),
+        PurePursuitController(lookahead_distance=2.0),
+        cruise_speed=1.0,
+        occupancy=_NearObstacleOccupancy(0.5, 0.0, clearance=2.0),
+        repulsion_gain=2.0,
+        avoidance=noop,
+    )
+    assert loop._repulsion_turn_rate(0.0, 0.0, 0.0) == 0.0
+    metrics = loop.step(STRAIGHT_PATH, dt=0.1)
+    assert metrics["repulsion_turn_rate"] == 0.0
+
+
+def test_default_apf_matches_standalone_apf() -> None:
+    """TrackingLoop default APF matches a standalone ArtificialPotentialField."""
+    occ = _NearObstacleOccupancy(1.0, -1.0, clearance=4.0)
+    gain = 1.75
+    standalone = ArtificialPotentialField(occ, repulsion_gain=gain)
+    loop = TrackingLoop(
+        _make_vehicle(),
+        PurePursuitController(lookahead_distance=2.0),
+        cruise_speed=1.0,
+        occupancy=occ,
+        repulsion_gain=gain,
+    )
+    assert loop._repulsion_turn_rate(0.0, 0.0, 0.0) == standalone(
+        0.0, 0.0, 0.0
+    )

--- a/tests/guidance/test_public_api.py
+++ b/tests/guidance/test_public_api.py
@@ -1,0 +1,21 @@
+"""Tests for guidance public API surface."""
+
+from __future__ import annotations
+
+from arco import guidance
+from arco.guidance import MovingAverageInterpolator
+from arco.guidance.interpolation import MovingAverageInterpolator as MADeep
+
+
+def test_moving_average_exported_from_guidance():
+    assert MovingAverageInterpolator is MADeep
+    assert "MovingAverageInterpolator" in guidance.__all__
+
+
+def test_subpackage_all_exports():
+    from arco.mapping import grid
+    from arco.planning import continuous, discrete
+
+    assert "ManhattanGrid" in grid.__all__
+    assert "RRTPlanner" in continuous.__all__
+    assert "AStarPlanner" in discrete.__all__

--- a/tests/mapping/test_segment_free.py
+++ b/tests/mapping/test_segment_free.py
@@ -1,0 +1,41 @@
+"""Tests for Occupancy.segment_free shared collision checks."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from arco.mapping.kdtree import KDTreeOccupancy
+from arco.mapping.occupancy import Occupancy
+from arco.planning import RRTPlanner
+
+
+class _WallOccupancy(Occupancy):
+    def nearest_obstacle(self, point: np.ndarray):
+        return abs(float(point[0]) - 0.5), np.array([0.5, point[1]])
+
+    def is_occupied(self, point: np.ndarray) -> bool:
+        return abs(float(point[0]) - 0.5) < 0.05
+
+
+def test_occupancy_segment_free_default_blocks_wall():
+    occ = _WallOccupancy()
+    assert occ.segment_free(np.array([0.0, 0.0]), np.array([0.0, 1.0]))
+    assert not occ.segment_free(np.array([0.0, 0.0]), np.array([1.0, 0.0]))
+
+
+def test_occupancy_default_clearance_and_query_distances():
+    occ = _WallOccupancy()
+    assert occ.clearance == 0.0
+    dists = occ.query_distances(np.array([[0.0, 0.0], [0.5, 0.0]]))
+    assert dists.shape == (2,)
+    assert dists[1] < dists[0]
+
+
+def test_rrt_uses_occupancy_segment_free():
+    occ = KDTreeOccupancy(np.array([[10.0, 10.0]]), clearance=0.1)
+    planner = RRTPlanner(
+        occ, bounds=[(0.0, 1.0), (0.0, 1.0)], max_sample_count=1
+    )
+    assert planner.is_segment_free(
+        np.array([0.0, 0.0]), np.array([0.5, 0.5])
+    )

--- a/tests/planning/continuous/test_cost_injection.py
+++ b/tests/planning/continuous/test_cost_injection.py
@@ -1,0 +1,49 @@
+"""Tests for continuous planner cost= composition."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from arco.mapping.occupancy import Occupancy
+from arco.planning import RRTPlanner
+from arco.planning.cost import PlannerCost
+
+
+class _OpenOccupancy(Occupancy):
+    def is_occupied(self, position: np.ndarray) -> bool:
+        return False
+
+    def nearest_obstacle(self, position: np.ndarray):
+        return float("inf"), position
+
+
+class _ScaledCost(PlannerCost):
+    def distance(self, state_a, state_b) -> float:
+        return 2.0 * super().distance(state_a, state_b)
+
+
+def test_cost_injection_delegates_distance():
+    occ = _OpenOccupancy()
+    cost = _ScaledCost()
+    planner = RRTPlanner(
+        occ,
+        bounds=[(0.0, 5.0), (0.0, 5.0)],
+        step_size=1.0,
+        max_sample_count=1,
+        cost=cost,
+    )
+    a = np.array([0.0, 0.0])
+    b = np.array([3.0, 4.0])
+    assert planner.distance(a, b) == 10.0
+    assert planner.heuristic(a, b) == 10.0
+
+
+def test_default_cost_still_step_normalized():
+    occ = _OpenOccupancy()
+    planner = RRTPlanner(
+        occ,
+        bounds=[(0.0, 5.0), (0.0, 5.0)],
+        step_size=np.array([2.0, 1.0]),
+        max_sample_count=1,
+    )
+    assert planner.distance(np.array([0.0, 0.0]), np.array([2.0, 0.0])) == 1.0

--- a/tests/planning/continuous/test_cost_terms.py
+++ b/tests/planning/continuous/test_cost_terms.py
@@ -1,0 +1,185 @@
+"""Tests for TrajectoryOptimizer cost_terms injection (Tier C2)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import numpy as np
+
+from arco.mapping import KDTreeOccupancy
+from arco.planning.continuous import TrajectoryOptimizer
+from arco.planning.continuous.cost_terms import (
+    CollisionCostTerm,
+    DeviationCostTerm,
+    DynamicsCostTerm,
+    TimeCostTerm,
+    VelocityCostTerm,
+    build_default_cost_terms,
+)
+from arco.protocols import CostTerm
+
+
+def _free_occupancy(clearance=0.3):
+    return KDTreeOccupancy([[200.0, 200.0]], clearance=clearance)
+
+
+class _ConstantTerm:
+    """Minimal CostTerm that adds a fixed offset."""
+
+    name = "constant"
+
+    def __init__(self, value: float) -> None:
+        self.value = float(value)
+
+    def __call__(self, context: Dict[str, Any]) -> float:
+        return self.value
+
+
+def test_default_cost_terms_has_five_named_terms():
+    terms = build_default_cost_terms(
+        weight_time=1.0,
+        weight_deviation=1.0,
+        weight_velocity=1.0,
+        weight_collision=1.0,
+        weight_dynamics=1.0,
+        cruise_speed=1.0,
+        collision_barrier_scale=50.0,
+        collision_barrier_power=4.0,
+        max_speed=None,
+        min_speed=None,
+    )
+    assert len(terms) == 5
+    assert [t.name for t in terms] == [
+        "time",
+        "deviation",
+        "velocity",
+        "collision",
+        "dynamics",
+    ]
+    assert all(isinstance(t, CostTerm) for t in terms)
+
+
+def test_optimizer_builds_five_default_terms():
+    occ = _free_occupancy()
+    opt = TrajectoryOptimizer(occ, cruise_speed=1.0)
+    assert len(opt.cost_terms) == 5
+    assert [t.name for t in opt.cost_terms] == [
+        "time",
+        "deviation",
+        "velocity",
+        "collision",
+        "dynamics",
+    ]
+
+
+def test_default_terms_match_analytical_time_only():
+    """Default time term must match w_time · T² exactly."""
+    occ = _free_occupancy()
+    opt = TrajectoryOptimizer(
+        occ,
+        weight_time=3.0,
+        weight_deviation=0.0,
+        weight_velocity=0.0,
+        weight_collision=0.0,
+        weight_dynamics=0.0,
+        collision_barrier_scale=0.0,
+    )
+    ref = [np.array([0.0, 0.0]), np.array([4.0, 0.0])]
+    x = np.array([2.5])
+    # T = 2.5 → J = 3 * 2.5² = 18.75
+    assert opt._cost(x, ref, 1, 2) == 3.0 * 2.5**2
+
+
+def test_custom_cost_term_injection_replaces_defaults():
+    occ = _free_occupancy()
+    custom: List[CostTerm] = [_ConstantTerm(7.5)]
+    opt = TrajectoryOptimizer(occ, cost_terms=custom)
+    assert len(opt.cost_terms) == 1
+    ref = [np.array([0.0, 0.0]), np.array([1.0, 0.0])]
+    x = np.array([1.0])
+    assert opt._cost(x, ref, 1, 2) == 7.5
+
+
+def test_custom_term_appended_to_defaults_increases_cost():
+    occ = _free_occupancy()
+    base = TrajectoryOptimizer(
+        occ,
+        weight_time=1.0,
+        weight_deviation=0.0,
+        weight_velocity=0.0,
+        weight_collision=0.0,
+        weight_dynamics=0.0,
+        collision_barrier_scale=0.0,
+    )
+    augmented_terms = list(base.cost_terms) + [_ConstantTerm(5.0)]
+    aug = TrajectoryOptimizer(
+        occ,
+        weight_time=1.0,
+        weight_deviation=0.0,
+        weight_velocity=0.0,
+        weight_collision=0.0,
+        weight_dynamics=0.0,
+        collision_barrier_scale=0.0,
+        cost_terms=augmented_terms,
+    )
+    ref = [np.array([0.0, 0.0]), np.array([4.0, 0.0])]
+    x = np.array([2.0])
+    assert aug._cost(x, ref, 1, 2) == base._cost(x, ref, 1, 2) + 5.0
+
+
+def test_individual_default_terms_evaluate():
+    occ = _free_occupancy()
+    ref = [
+        np.array([0.0, 0.0]),
+        np.array([4.0, 1.0]),
+        np.array([8.0, 0.0]),
+    ]
+    opt = TrajectoryOptimizer(
+        occ,
+        cruise_speed=2.0,
+        weight_time=2.0,
+        weight_deviation=3.0,
+        weight_velocity=4.0,
+        weight_collision=0.0,
+        weight_dynamics=0.0,
+        collision_barrier_scale=0.0,
+        sample_count=0,
+    )
+    # durations 1,1; interior at (4, 3) vs ref (4, 1)
+    x = np.array([1.0, 1.0, 4.0, 3.0])
+    durations, waypoints = opt._unpack(x, ref, 2, 2)
+    pts = np.array(waypoints)
+    durs = np.maximum(durations, 1e-9)
+    lengths = np.linalg.norm(pts[1:] - pts[:-1], axis=1)
+    speeds = lengths / durs
+    context = {
+        "durs": durs,
+        "pts": pts,
+        "speeds": speeds,
+        "ref": ref,
+        "segment_count": 2,
+        "occupancy": occ,
+        "sample_count": 0,
+    }
+
+    assert TimeCostTerm(2.0)(context) == 2.0 * (1.0 + 1.0) ** 2
+    assert DeviationCostTerm(3.0)(context) == 3.0 * (3.0 - 1.0) ** 2
+    expected_vel = 4.0 * float(np.sum((speeds - 2.0) ** 2))
+    assert VelocityCostTerm(4.0, 2.0)(context) == expected_vel
+    assert CollisionCostTerm(0.0)(context) == 0.0
+    assert DynamicsCostTerm(0.0)(context) == 0.0
+
+
+def test_defaults_still_optimize():
+    occ = _free_occupancy()
+    opt = TrajectoryOptimizer(
+        occ,
+        cruise_speed=2.0,
+        weight_time=10.0,
+        max_iter=20,
+    )
+    ref = [np.array([0.0, 5.0]), np.array([4.0, 5.0]), np.array([8.0, 5.0])]
+    result = opt.optimize(ref)
+    assert len(result.states) == 3
+    assert len(result.durations) == 2
+    assert np.isfinite(result.cost)

--- a/tests/planning/continuous/test_policy_hooks.py
+++ b/tests/planning/continuous/test_policy_hooks.py
@@ -1,0 +1,94 @@
+"""Tests for RRT/SST policy injection hooks."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from arco.mapping.occupancy import Occupancy
+from arco.planning import RRTPlanner, SSTPlanner
+
+
+class _OpenOccupancy(Occupancy):
+    def is_occupied(self, position: np.ndarray) -> bool:
+        return False
+
+    def nearest_obstacle(self, position: np.ndarray):
+        return float("inf"), position
+
+
+def test_rrt_custom_sampler_is_used():
+    occ = _OpenOccupancy()
+    calls = {"n": 0}
+
+    def sampler(rng):
+        calls["n"] += 1
+        return np.array([4.5, 4.5])
+
+    planner = RRTPlanner(
+        occ,
+        bounds=[(0.0, 5.0), (0.0, 5.0)],
+        max_sample_count=50,
+        goal_bias=0.0,
+        sampler=sampler,
+        early_stop=True,
+    )
+    path = planner.plan(np.array([0.5, 0.5]), np.array([4.5, 4.5]))
+    assert path is not None
+    assert calls["n"] > 0
+
+
+def test_rrt_custom_steerer_is_used():
+    occ = _OpenOccupancy()
+    calls = {"n": 0}
+
+    def steerer(a, b):
+        calls["n"] += 1
+        return a + 0.5 * (b - a)
+
+    planner = RRTPlanner(
+        occ,
+        bounds=[(0.0, 5.0), (0.0, 5.0)],
+        max_sample_count=200,
+        goal_bias=0.5,
+        steerer=steerer,
+        early_stop=True,
+    )
+    path = planner.plan(np.array([0.5, 0.5]), np.array([4.5, 4.5]))
+    assert path is not None
+    assert calls["n"] > 0
+
+
+def test_rrt_custom_segment_free_can_block_all():
+    occ = _OpenOccupancy()
+
+    planner = RRTPlanner(
+        occ,
+        bounds=[(0.0, 5.0), (0.0, 5.0)],
+        max_sample_count=50,
+        goal_bias=0.5,
+        segment_free=lambda a, b: False,
+        early_stop=True,
+    )
+    path = planner.plan(np.array([0.5, 0.5]), np.array([4.5, 4.5]))
+    assert path is None
+
+
+def test_sst_custom_sampler_is_used():
+    occ = _OpenOccupancy()
+    calls = {"n": 0}
+
+    def sampler(rng):
+        calls["n"] += 1
+        return np.array([4.5, 4.5])
+
+    planner = SSTPlanner(
+        occ,
+        bounds=[(0.0, 5.0), (0.0, 5.0)],
+        max_sample_count=80,
+        goal_bias=0.0,
+        sampler=sampler,
+        early_stop=True,
+    )
+    path = planner.plan(np.array([0.5, 0.5]), np.array([4.5, 4.5]))
+    assert path is not None
+    assert calls["n"] > 0

--- a/tests/planning/continuous/test_telemetry_rng.py
+++ b/tests/planning/continuous/test_telemetry_rng.py
@@ -1,0 +1,67 @@
+"""Tests for telemetry publisher and RNG injection."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from arco.mapping.occupancy import Occupancy
+from arco.planning import RRTPlanner
+from arco.planning.continuous.telemetry import noop_publisher
+
+
+class _OpenOccupancy(Occupancy):
+    def is_occupied(self, position: np.ndarray) -> bool:
+        return False
+
+    def nearest_obstacle(self, position: np.ndarray):
+        return float("inf"), position
+
+
+def test_custom_publisher_receives_snapshots():
+    occ = _OpenOccupancy()
+    snapshots = []
+
+    planner = RRTPlanner(
+        occ,
+        bounds=[(0.0, 5.0), (0.0, 5.0)],
+        max_sample_count=150,
+        goal_bias=0.5,
+        publisher=snapshots.append,
+        seed=0,
+        early_stop=True,
+    )
+    path = planner.plan(np.array([0.5, 0.5]), np.array([4.5, 4.5]))
+    assert path is not None
+    assert len(snapshots) >= 1
+
+
+def test_noop_publisher_disables_default_ipc():
+    occ = _OpenOccupancy()
+    planner = RRTPlanner(
+        occ,
+        bounds=[(0.0, 2.0), (0.0, 2.0)],
+        max_sample_count=20,
+        publisher=noop_publisher,
+        seed=1,
+    )
+    # Should not raise even if temp file is unavailable.
+    planner.plan(np.array([0.1, 0.1]), np.array([1.9, 1.9]))
+
+
+def test_seed_makes_sampling_deterministic():
+    occ = _OpenOccupancy()
+    kwargs = dict(
+        occupancy=occ,
+        bounds=[(0.0, 5.0), (0.0, 5.0)],
+        max_sample_count=80,
+        goal_bias=0.1,
+        publisher=noop_publisher,
+        seed=42,
+        early_stop=False,
+    )
+    p1 = RRTPlanner(**kwargs).plan(np.array([0.5, 0.5]), np.array([4.0, 4.0]))
+    p2 = RRTPlanner(**kwargs).plan(np.array([0.5, 0.5]), np.array([4.0, 4.0]))
+    assert p1 is not None and p2 is not None
+    assert len(p1) == len(p2)
+    for a, b in zip(p1, p2):
+        assert np.allclose(a, b)

--- a/tests/planning/discrete/test_injection_flags.py
+++ b/tests/planning/discrete/test_injection_flags.py
@@ -1,0 +1,46 @@
+"""Tests for A* flags and RouteRouter planner injection."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from arco.mapping import ManhattanGrid
+from arco.mapping.graph.cartesian import CartesianGraph
+from arco.planning.discrete import AStarPlanner, RouteRouter
+
+
+def test_astar_simplify_path_can_be_disabled():
+    grid = ManhattanGrid((1, 6))
+    planner = AStarPlanner(grid, simplify_path=False)
+    path = planner.plan((0, 0), (0, 5))
+    assert path is not None
+    assert len(path) == 6
+
+
+def test_astar_prefer_straight_false_still_finds_path():
+    grid = ManhattanGrid((5, 5))
+    planner = AStarPlanner(grid, prefer_straight=False)
+    path = planner.plan((0, 0), (4, 4))
+    assert path is not None
+    assert path[0] == (0, 0)
+    assert path[-1] == (4, 4)
+
+
+def test_route_router_accepts_custom_planner():
+    g = CartesianGraph()
+    g.add_node(0, 0.0, 0.0)
+    g.add_node(1, 1.0, 0.0)
+    g.add_edge(0, 1)
+
+    calls = {"n": 0}
+
+    class _Spy:
+        def plan(self, start, goal):
+            calls["n"] += 1
+            return [start, goal]
+
+    router = RouteRouter(g, planner=_Spy())
+    result = router.plan(np.array([0.0, 0.0]), np.array([1.0, 0.0]))
+    assert result is not None
+    assert calls["n"] == 1
+    assert result.path == [0, 1]

--- a/tests/planning/test_cost.py
+++ b/tests/planning/test_cost.py
@@ -1,0 +1,152 @@
+"""Functional tests for PlannerCost defaults and planner inheritance."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from arco.mapping import ManhattanGrid
+from arco.mapping.occupancy import Occupancy
+from arco.planning.continuous import ContinuousPlanner, RRTPlanner, SSTPlanner
+from arco.planning.cost import PlannerCost
+from arco.planning.discrete import AStarPlanner, DiscretePlanner
+
+
+class _BareCost(PlannerCost):
+    """Minimal subclass used to exercise default cost methods."""
+
+
+class _OpenOccupancy(Occupancy):
+    """Occupancy map with no obstacles."""
+
+    def is_occupied(self, position: np.ndarray) -> bool:
+        return False
+
+    def nearest_obstacle(self, position: np.ndarray):
+        return float("inf"), position
+
+
+def test_planner_cost_default_distance_is_euclidean():
+    cost = _BareCost()
+    assert cost.distance([0.0, 0.0], [3.0, 4.0]) == pytest.approx(5.0)
+
+
+def test_planner_cost_default_heuristic_matches_distance():
+    cost = _BareCost()
+    a = np.array([1.0, 2.0, 3.0])
+    b = np.array([4.0, 6.0, 3.0])
+    assert cost.heuristic(a, b) == pytest.approx(cost.distance(a, b))
+
+
+def test_discrete_and_continuous_bases_inherit_planner_cost():
+    assert issubclass(DiscretePlanner, PlannerCost)
+    assert issubclass(ContinuousPlanner, PlannerCost)
+
+
+def test_astar_rrt_sst_inherit_planner_cost():
+    assert issubclass(AStarPlanner, PlannerCost)
+    assert issubclass(RRTPlanner, PlannerCost)
+    assert issubclass(SSTPlanner, PlannerCost)
+
+
+def test_astar_uses_overridable_distance_and_heuristic():
+    grid = ManhattanGrid((4, 4))
+
+    class CountingAStar(AStarPlanner):
+        def __init__(self, graph):
+            super().__init__(graph)
+            self.distance_calls = 0
+            self.heuristic_calls = 0
+
+        def distance(self, state_a, state_b) -> float:
+            self.distance_calls += 1
+            return super().distance(state_a, state_b)
+
+        def heuristic(self, state_a, state_b) -> float:
+            self.heuristic_calls += 1
+            return super().heuristic(state_a, state_b)
+
+    planner = CountingAStar(grid)
+    path = planner.plan((0, 0), (3, 3))
+    assert path is not None
+    assert planner.distance_calls > 0
+    assert planner.heuristic_calls > 0
+
+
+def test_astar_custom_heuristic_callable_still_works():
+    grid = ManhattanGrid((5, 5))
+    calls = {"n": 0}
+
+    def zero_heuristic(node, goal) -> float:
+        calls["n"] += 1
+        return 0.0
+
+    planner = AStarPlanner(grid, heuristic=zero_heuristic)
+    path = planner.plan((0, 0), (4, 4))
+    assert path is not None
+    assert calls["n"] > 0
+
+
+def test_continuous_distance_uses_step_size_normalization():
+    occ = _OpenOccupancy()
+    planner = RRTPlanner(
+        occ,
+        bounds=[(0.0, 10.0), (0.0, 10.0)],
+        step_size=np.array([2.0, 1.0]),
+        max_sample_count=1,
+    )
+    a = np.array([0.0, 0.0])
+    b = np.array([2.0, 0.0])
+    # Normalized delta = (1, 0) → distance 1.
+    assert planner.distance(a, b) == pytest.approx(1.0)
+    assert planner.heuristic(a, b) == pytest.approx(1.0)
+
+
+def test_rrt_uses_overridable_distance():
+    occ = _OpenOccupancy()
+
+    class CountingRRT(RRTPlanner):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.distance_calls = 0
+
+        def distance(self, state_a, state_b) -> float:
+            self.distance_calls += 1
+            return super().distance(state_a, state_b)
+
+    planner = CountingRRT(
+        occ,
+        bounds=[(0.0, 5.0), (0.0, 5.0)],
+        step_size=1.0,
+        max_sample_count=200,
+        goal_bias=0.3,
+        early_stop=True,
+    )
+    path = planner.plan(np.array([0.5, 0.5]), np.array([4.5, 4.5]))
+    assert path is not None
+    assert planner.distance_calls > 0
+
+
+def test_sst_uses_overridable_distance():
+    occ = _OpenOccupancy()
+
+    class CountingSST(SSTPlanner):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.distance_calls = 0
+
+        def distance(self, state_a, state_b) -> float:
+            self.distance_calls += 1
+            return super().distance(state_a, state_b)
+
+    planner = CountingSST(
+        occ,
+        bounds=[(0.0, 5.0), (0.0, 5.0)],
+        step_size=1.0,
+        max_sample_count=300,
+        goal_bias=0.3,
+        early_stop=True,
+    )
+    path = planner.plan(np.array([0.5, 0.5]), np.array([4.5, 4.5]))
+    assert path is not None
+    assert planner.distance_calls > 0

--- a/tests/protocols/test_protocols.py
+++ b/tests/protocols/test_protocols.py
@@ -1,0 +1,60 @@
+"""Tests for arco.protocols structural contracts."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from arco.control.pure_pursuit import PurePursuitController
+from arco.guidance.vehicle import DubinsVehicle
+from arco.mapping import EuclideanGrid, KDTreeOccupancy, ManhattanGrid
+from arco.planning import AStarPlanner, RRTPlanner, TrajectoryPruner
+from arco.planning.continuous.optimizer import TrajectoryOptimizer
+from arco.protocols import (
+    DiscreteMap,
+    OccupancyLike,
+    OptimizerLike,
+    PathTracker,
+    PlannerLike,
+    PrunerLike,
+    VehicleModel,
+)
+
+
+def test_grids_satisfy_discrete_map_protocol():
+    assert isinstance(ManhattanGrid((3, 3)), DiscreteMap)
+    assert isinstance(EuclideanGrid((3, 3)), DiscreteMap)
+
+
+def test_kdtree_occupancy_satisfies_occupancy_like():
+    occ = KDTreeOccupancy(np.array([[0.0, 0.0], [1.0, 1.0]]), clearance=0.5)
+    assert isinstance(occ, OccupancyLike)
+
+
+def test_rrt_satisfies_planner_like():
+    occ = KDTreeOccupancy(np.array([[10.0, 10.0]]), clearance=0.1)
+    planner = RRTPlanner(
+        occ, bounds=[(0.0, 1.0), (0.0, 1.0)], max_sample_count=1
+    )
+    assert isinstance(planner, PlannerLike)
+
+
+def test_pruner_and_optimizer_protocols():
+    occ = KDTreeOccupancy(np.array([[10.0, 10.0]]), clearance=0.1)
+    pruner = TrajectoryPruner(occ, step_size=np.array([1.0, 1.0]))
+    opt = TrajectoryOptimizer(occ, weight_time=1.0)
+    assert isinstance(pruner, PrunerLike)
+    assert isinstance(opt, OptimizerLike)
+
+
+def test_pure_pursuit_satisfies_path_tracker():
+    assert isinstance(PurePursuitController(), PathTracker)
+
+
+def test_dubins_vehicle_satisfies_vehicle_model():
+    assert isinstance(DubinsVehicle(), VehicleModel)
+
+
+def test_astar_graph_satisfies_discrete_map():
+    grid = ManhattanGrid((4, 4))
+    planner = AStarPlanner(grid)
+    assert isinstance(planner.graph, DiscreteMap)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal / objectives

Full backwards-compatible modularity upgrade for ARCO planning, mapping, guidance, and control. Existing call sites keep historical defaults; every new hook is optional.

## Tier A — document & formalize
1. **`arco.protocols`** — structural Protocols (`DiscreteMap`, `OccupancyLike`, `PlannerLike`/`PrunerLike`/`OptimizerLike`, `PathTracker`, `VehicleModel`, `Sampler`/`Steerer`/`SegmentChecker`, `AvoidanceStrategy`, `TelemetryPublisher`, `CostTerm`)
2. **Docs** — extension-point table; clarify `ExplorationPrimitive` is not auto-wired into RRT/SST
3. **Public API** — export `MovingAverageInterpolator`; add subpackage `__all__`

## Tier B — optional composition hooks
1. RRT*/SST: `sampler=` / `steerer=` / `segment_free=`
2. Continuous: `cost=` (`PlannerCost` composition)
3. `RouteRouter(planner=…)`; A* `simplify_path` / `prefer_straight`
4. Telemetry `publisher=` + `seed=` / `rng=`; `noop_publisher`

## Tier C — shared implementations
1. `Occupancy.segment_free` (+ `clearance` / `query_distances` defaults); RRT*/SST/pruner use them
2. `TrajectoryOptimizer(cost_terms=…)` with five default terms
3. `ArtificialPotentialField` + `TrackingLoop(avoidance=…)` typed to protocols
4. Wire `mpc.costs` helpers into path-following and joint-space MPC

## Acceptance
- Defaults preserve prior behavior
- Overrides are opt-in
- Formatting, unit tests, and smoke (`city`/`ppp`/`rrp`/`occ`) pass

## Verification
- `bash scripts/check_formatting.sh` — pass
- `bash scripts/run_tests.sh` — 879 passed, 2 xfailed
- Smoke: city, ppp, rrp, occ — pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-162eef6e-f4d4-49ef-a4bf-46caf54f3290?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-162eef6e-f4d4-49ef-a4bf-46caf54f3290&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

